### PR TITLE
fix/Fixing Contributing Link on Readme Documentation File

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
       📚 Documentation
     </a>
     <span> | </span>
-    <a href="https://github.com/laradumps/laradumps#contribution">
+    <a href="https://github.com/laradumps/app/blob/main/CONTRIBUTING.md">
       ⌨️ Contribution
     </a>
   </h3>


### PR DESCRIPTION
As the `Contributions` section has been removed from the `Readme` I am making this update.

Before
```html
<div align="center">
  <h3> 
    <a href="https://laradumps.gitbook.io/get-started/">
      📚 Documentation
    </a>
    <span> | </span>
    <a href="https://github.com/laradumps/laradumps#contribution">
      ⌨️ Contribution
    </a>
  </h3>
</div>
```

After
```html
<div align="center">
  <h3> 
    <a href="https://laradumps.gitbook.io/get-started/">
      📚 Documentation
    </a>
    <span> | </span>
    <a href="https://github.com/laradumps/app/blob/main/CONTRIBUTING.md">
      ⌨️ Contribution
    </a>
  </h3>
</div>
```