### PR TITLE
Hidding SQL connection in privacy mode and time unit

### DIFF
--- a/src/renderer/js/alpinejs/dumper.js
+++ b/src/renderer/js/alpinejs/dumper.js
@@ -254,13 +254,14 @@ export default () => ({
         connectionInfo.innerHTML = `
             <div class="flex justify-between">
                 <div class="text-sm text-slate-500 dark:text-slate-400">
-                     connection/database
-                     <div class="text-sm text-slate-500 dark:text-slate-400 font-bold">
+                     <span class="privacyMode">connection/database</span>
+                     <div class="privacyMode text-sm text-slate-500 dark:text-slate-400 font-bold">
                          ${queries.connectionName}/${queries.database}
                      </div>
                  </div>
                  <div class="text-sm text-slate-500 dark:text-slate-400">
-                     time: <span class="text-base font-bold text-slate-600 dark:text-slate-200">${queries.time}</span>
+                     time: <span class="text-base font-bold text-slate-600 dark:text-slate-200">${queries.time}</span><span class="text-xs text-slate-500 dark:text-slate-400"> ms</span>
+
                  </div>
             </div>`;
 


### PR DESCRIPTION
Hi Luan,

This PR enhances the Privacy Mode feature by also hiding the SQL Connection. I believe this can be considered sensitive data even in development mode, as devs might not want to share in which DB they currently work in.

I propose a minor change, I have added  "ms"  to the query time to make the measurement unit clear.

<img width="768" alt="CleanShot 2022-06-28 at 09 41 15@2x" src="https://user-images.githubusercontent.com/79267265/176122174-ddfec22f-a1b6-4b7c-ac8f-599eb4c30460.png">

Greetings and thanks,

Dan

