### PR TITLE
[1.0] Fix screen name bug

### DIFF
--- a/src/renderer/js/alpinejs/app.js
+++ b/src/renderer/js/alpinejs/app.js
@@ -115,7 +115,7 @@ export default () => ({
     privacyMode: false,
     privacyElements: [],
     ideHandle: null,
-    activeScreen: 'screen 1',
+    activeScreen: 'laraDumpsScrn-screen 1',
     defaultScreenName: null,
     screenList: [],
     dumpBatch: [],

--- a/src/renderer/js/alpinejs/dumper.js
+++ b/src/renderer/js/alpinejs/dumper.js
@@ -19,7 +19,7 @@ export default () => ({
         window.addEventListener('dumper:screen', ({ detail }) => {
             const { label } = detail;
             if (document.getElementById(this.notificationId) != null) {
-                document.getElementById(this.notificationId).setAttribute('class', `filterScreen ${label} collapsable p-3 mb-4 shadow-md rounded dark:bg-slate-700 bg-white border-slate-300 dark:border-slate-600 cursor-pointer align-middle items-start font-medium text-gray-500 hidden`);
+                document.getElementById(this.notificationId).setAttribute('class', `filterScreen laraDumpsScrn-${label} collapsable p-3 mb-4 shadow-md rounded dark:bg-slate-700 bg-white border-slate-300 dark:border-slate-600 cursor-pointer align-middle items-start font-medium text-gray-500 hidden`);
             }
         });
         window.addEventListener('dumper:dump', ({ detail }) => {
@@ -471,7 +471,7 @@ export default () => ({
                 }" 
                 x-init="initCollapsableElements" 
                 id="${notificationId}"
-               class="filterScreen collapsable screen 1 ${encodedFilePath} rounded-sm collapsable p-4 mb-4 w-full p-3 shadow-lg text-sm bg-white rounded-sm dark:text-slate-300 dark:bg-slate-700">
+               class="filterScreen collapsable laraDumpsScrn-screen 1 ${encodedFilePath} rounded-sm collapsable p-4 mb-4 w-full p-3 shadow-lg text-sm bg-white rounded-sm dark:text-slate-300 dark:bg-slate-700">
                 <div x-on:click="toggleCollapse" class="flex justify-between w-full cursor-pointer ">
                    <div class="flex items-center justify-center">
                       <div id="color-${notificationId}" class="items-center w-[0.72rem] h-[0.72rem] mr-2 rounded-full bg-slate-300 dark:bg-gray-500"></div>

--- a/src/renderer/js/filterScreen.js
+++ b/src/renderer/js/filterScreen.js
@@ -26,6 +26,8 @@ const filterScreen = (screenName) => {
 
     const x = document.getElementsByClassName('filterScreen');
     if (screenName === 'all') screenName = '';
+    if (screenName != '') screenName = 'laraDumpsScrn-' + screenName;
+
     for (i = 0; i < x.length; i += 1) {
         removeClass(x[i], 'show');
         if (x[i].className.indexOf(screenName) > -1) addClass(x[i], 'show');


### PR DESCRIPTION
Hi Luan,

This PR fixes a bug in the screen name resulting in:

![PR](https://user-images.githubusercontent.com/79267265/178073476-33149c2e-4347-4b3b-bb8a-cbd657b5b0e8.gif)

---

**MOTIVATION**

When the user sends a screen name with a character that matches an existing CSS class, for instance `2` matches  "mx-**2**", the screen filter gets confused.

Also, if a screen name happens to match a valid CSS class, it gets rendered and applied. It is like a "CSS Injection".

```php
ds('Dump me in screen 1');
ds('Dump me in screen: 2')->s('2');
ds('Dump me in screen: dark')->s('dark');
```

The code above produces:

<img width="768" alt="no filter" src="https://user-images.githubusercontent.com/79267265/178073261-21d69c15-78c6-44b2-994f-c478c2cc548a.png">

_Filter glitch_

<img width="812" alt="css leak" src="https://user-images.githubusercontent.com/79267265/178073243-37430bb2-5708-476d-a1a5-41c6cdda9d19.png">

_CSS rendering_

---

Please let me know if any adjustment is needed.

Greetings and thanks,

Dan