### PR TITLE
[1.0] Clipboard copy MacOS

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -145,18 +145,20 @@ function createWindow() {
 }
 
 function createMenu() {
-    const menu = Menu.buildFromTemplate([
-        {
+    let menuTemplate = [{
             label: 'Menu',
-            submenu: [
-                {
+            submenu: [{
                     label: 'About LaraDumps',
                     click: async () => {
-                        const { shell } = require('electron');
+                        const {
+                            shell
+                        } = require('electron');
                         await shell.openExternal('https://github.com/laradumps/app');
                     },
                 },
-                { type: 'separator' },
+                {
+                    type: 'separator'
+                },
                 {
                     label: 'Quit LaraDumps',
                     click() {
@@ -167,25 +169,44 @@ function createMenu() {
         },
         {
             label: 'Help',
-            submenu: [
-                {
+            submenu: [{
                     label: 'Documentation',
                     click: async () => {
-                        const { shell } = require('electron');
+                        const {
+                            shell
+                        } = require('electron');
                         await shell.openExternal('https://laradumps.dev');
                     },
                 },
-                { type: 'separator' },
+                {
+                    type: 'separator'
+                },
                 {
                     label: 'Releases',
                     click: async () => {
-                        const { shell } = require('electron');
+                        const {
+                            shell
+                        } = require('electron');
                         await shell.openExternal('https://github.com/laradumps/app/releases');
                     },
                 },
             ],
-        },
-    ]);
+        }
+    ];
+
+    //Enables copy to clipboard in MacOS
+    if (process.platform === 'darwin') {
+        menuTemplate.splice(1, 0, {
+            label: 'Edit',
+            submenu: [{
+                label: 'Copy',
+                accelerator: 'CmdOrCtrl+C',
+                selector: 'copy:'
+            }]
+        });
+    }
+
+    const menu = Menu.buildFromTemplate(menuTemplate);
     Menu.setApplicationMenu(menu);
 }
 


### PR DESCRIPTION
Hi Luan,

This PR enables `⌘+C` and `Edit > Copy` menu for MacOS and resolves the issue https://github.com/laradumps/app/issues/40.

<img width="728" alt="CleanShot 2022-07-10 at 12 56 08@2x" src="https://user-images.githubusercontent.com/79267265/178142046-8c8ea019-1aa1-486e-8cad-bf5dd80ff4b8.png">

_Select text, ⌘+C and ⌘+V succesfully executed._

Greetings and thanks,

Dan