### PR TITLE
Fix "Screen 1" not being active by default

### DIFF
--- a/src/renderer/js/alpinejs/app.js
+++ b/src/renderer/js/alpinejs/app.js
@@ -125,7 +125,7 @@ export default () => ({
     privacyMode: false,
     privacyElements: [],
     ideHandle: null,
-    activeScreen: 'laraDumpsScreen-screen 1',
+    activeScreen: 'screen 1',
     defaultScreenName: null,
     screenList: [],
     dumpBatch: [],


### PR DESCRIPTION
Hi Luan,

This PR fixes the bug of "screen 1" not being active by default.

### EXPECTED BEHAVIOR

Screen 1 is selected by default when the first dump arrives.

<img src="https://user-images.githubusercontent.com/79267265/180183794-4cb1cc5f-ec61-408f-835f-767e10c64d7e.gif" width="400">

### BEFORE THE PR

User must figure out something happen and spontaneously click at "screen 1".

<img src="https://user-images.githubusercontent.com/79267265/180183761-ce4e6cad-f481-48cd-92f7-a6c5ec012cf0.gif" width="400">

Greetings and thanks,

Dan
