### PR TITLE
Fix Always On Top toggle on app launch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,14 +54,14 @@ yarn run prod
 
 <br/>
 
-5**Commit**
+5. **Commit**
 
 Please send clean and descriptive commits.
 
 <br/>
 
 
-6**Pull Request**
+6. **Pull Request**
 
 Open a Pull Request (PR) detailing your changes and motivations. Please make only one change per Pull Request.
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,8 @@ When using LaraDumps, you can see the result of your debug displayed in a standa
 
 ### Get Started
 
-1. Download the desktop app:
-
-  -[Windows](https://github.com/laradumps/app/releases/download/v1.1.1/LaraDumps-Setup-1.1.1.exe)
-
-  -[MacOS](https://github.com/laradumps/app/releases/download/v1.1.1/LaraDumps-1.1.1.dmg)
-
-  -[Linux](https://github.com/laradumps/app/releases/download/v1.1.1/LaraDumps-1.1.1.AppImage)
+1. Download the desktop App: [Windows](https://github.com/laradumps/app/releases/download/v1.1.1/LaraDumps-Setup-1.1.1.exe) | [MacOS](https://github.com/laradumps/app/releases/download/v1.1.1/LaraDumps-1.1.1.dmg)
+ | [Linux](https://github.com/laradumps/app/releases/download/v1.1.1/LaraDumps-1.1.1.AppImage)
 
 2. Proceed to install the [LaraDumps](https://github.com/laradumps/laradumps) Laravel package in your project.
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -301,6 +301,10 @@ ipcMain.on('main:toggle-always-on-top', (event, arg) => {
     setTimeout(() => mainWindow.setAlwaysOnTop(arg), 200);
 });
 
+ipcMain.on('main:is-always-on-top', () => {
+    mainWindow.webContents.send('main:is-always-on-top', { is_always_on_top: mainWindow.isAlwaysOnTop() });
+});
+
 ipcMain.on('main:get-app-version', () => {
     mainWindow.webContents.send('main:app-version', { version: app.getVersion() });
 });

--- a/src/renderer/js/alpinejs/app.js
+++ b/src/renderer/js/alpinejs/app.js
@@ -160,6 +160,8 @@ export default () => ({
 
         ipcRenderer.send('main:get-app-version');
 
+        ipcRenderer.send('main:is-always-on-top');
+
         this.defaultScreen();
 
         storage.setDataPath(os.tmpdir());
@@ -280,6 +282,10 @@ export default () => ({
         ipcRenderer.on('clear', () => this.clear());
 
         ipcRenderer.on('events', (event, arg) => this.dispatchDump('events', arg.content));
+
+        ipcRenderer.on('main:is-always-on-top', (event, arg) => {
+            this.isAlwaysOnTop = arg.is_always_on_top;
+        });
 
         ipcRenderer.on('main:app-version', (event, arg) => {
             document.title = `LaraDumps - ${arg.version}`;


### PR DESCRIPTION
Hello Luan,

This PR fixes the "Always On Top" toggle being marked as `disabled` when the app launch with `Always on Top` enabled (default) and does not introduce any breaking changes.

I am also profiting the pull request to apply some minor styling fixes to the README and CONTRIBUTING files.

### BEFORE

The present situation forces the user to perform an extra click to toggle the Always On Top.

1. App is launched as `Always On Top` but button is `off`.
2. Click to disable. This results as enabling what is already enabled.
3. Button toggles to "on".
4. User must click again to disable.

![before](https://user-images.githubusercontent.com/79267265/184224435-1355f0db-f3d9-436c-afde-de689a04068e.gif)


### AFTER

1. App is launched as `Always On Top`, button is marked as `on`.
2. User clicks to disable.

![after](https://user-images.githubusercontent.com/79267265/184224427-52db1f68-d233-454e-8b6a-ecbac433fd99.gif)

---

I decided to adopt the approach of leaving `isAlwaysOnTop: false` and ask the `mainWindow` for the  Always on Top state to update it accordingly.

**app.js**

```js
//...

export default () => ({
    label: 'laradumps',
    dialog: {
        open: false, title: null, description: null, button: 'Ok',
    },
    dark: false,
    isAlwaysOnTop: false,

    //...

        ipcRenderer.on('main:is-always-on-top', (event, arg) => {
            this.isAlwaysOnTop = arg.is_always_on_top;
        });


```

**main.js**

```js
//..
ipcMain.on('main:is-always-on-top', () => {
    mainWindow.webContents.send('main:is-always-on-top', { is_always_on_top: mainWindow.isAlwaysOnTop() });
});
```

Please let me know if there are any changes required.

Greetings and thanks

Dan


