### PR TITLE
Fix dark mode toggle inverted icon

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -243,17 +243,19 @@
                                     <div>
                                         <!-- Lights ON -->
                                         <svg :class="{'hidden': !dark}" :stroke="dark ? '#a4b0c2' : '#64748b'"
-                                             class="w-5 h-5"
-                                             fill="none" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
-                                        </svg>
-                                        <!-- Lights OFF -->
-                                        <svg :class="{'hidden': dark}" :stroke="dark ? '#a4b0c2' : '#64748b'"
+
                                              class="w-5 h-5" fill="none" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                                   d="m9.663 17h4.673m-5.872-1.464c-3.1494-3.1502-0.91798-8.5348 3.536-8.5348 4.454 0 6.6854 5.3846 3.536 8.5348l-0.548 0.547c-0.63272 0.63284-0.98812 1.4911-0.988 2.386v0.531c0 2.6667-4 2.6667-4 0v-0.531c0-0.895-0.356-1.754-0.988-2.386z"/>
                                         </svg>
+                                        <!-- Lights OFF -->
+                                        <svg :class="{'hidden': dark}" :stroke="dark ? '#a4b0c2' : '#64748b'"
+                                        class="w-5 h-5"
+                                        fill="none" viewBox="0 0 24 24">
+                                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                             d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+                                   </svg>
+
                                     </div>
                                 </button>
                             </div>


### PR DESCRIPTION
Hello Luan,

This PR fixes the inverted icon for "Toggle Dark mode" and introduces no breaking changes.

Currently, LaraDumps shows "Lights on" when it is in Dark mode.

One could interpret that this means *click on the "light on" symbol to turn on the light* and understand the state by the "circled highlight" background. However, I think this deviates from the standards:

- Laravel documentation shows "the sun" when in Light mode.

![CleanShot 2022-08-12 at 13 26 45](https://user-images.githubusercontent.com/79267265/184346342-76a56c74-a5b0-4fef-8a43-23c2fd54ba1b.png)

- Vue.js shows "the moon" when in Dark mode.

![CleanShot 2022-08-12 at 13 33 10](https://user-images.githubusercontent.com/79267265/184346444-fbb31786-2057-4784-a860-b93bd64a90ba.png)

--- 

### Before

"Lights on" on Dark mode.

![CleanShot 2022-08-12 at 13 25 14](https://user-images.githubusercontent.com/79267265/184346472-7a57e422-5867-48a1-8d13-8abc290ed392.png)

### After

The button represents the app state. 

Lights on means "in light mode".

Lights off means "in dark mode".


![CleanShot 2022-08-12 at 13 21 40](https://user-images.githubusercontent.com/79267265/184346166-cd8c0298-ff98-43dd-b2f3-4a75dbbfc61d.gif)

Please let me know what you think.

Greetings and thanks,

Dan