### PR TITLE
Fix: Hides Dark mode toggle in Saved window

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -235,6 +235,7 @@
                                 </button>
                                 <!-- dark mode -->
                                 <button x-on:click="dark = !dark"
+                                        x-show="!savedDumpsWindow"
                                         x-bind:class="{
                                              'bg-slate-200 shadow border border-slate-300 dark:border-slate-600 dark:bg-slate-800' : dark
                                         }"


### PR DESCRIPTION
Hi Luan,

This PR hides the "Dark mode" toggle in the "Saved" window, as it is with the "Always on top" toggle.

<div align="center">
  <p align="center">

<img width="400" alt="CleanShot 2022-08-13 at 21 30 45@2x" src="https://user-images.githubusercontent.com/79267265/184508136-33dc574f-57b9-4002-bc66-71902c8f17c8.png">

  </p>
</div>




Greeting and thanks,

Dan