### PR TITLE
Remove global shortcut for ⌘+Q

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -197,8 +197,9 @@ function createMenu() {
         },
         {
             label: 'Quit LaraDumps',
+            accelerator: process.platform === 'darwin' ? 'Command+Q' : 'Ctrl+Q',
             click() {
-                app.quit();
+                app.quit(); 
             },
         },
         ],
@@ -296,12 +297,6 @@ app.whenReady().then(async () => {
     globalShortcut.register('CommandOrControl+Shift+X', () => {
         mainWindow.reload();
     });
-
-    if (process.platform === 'darwin') {
-        globalShortcut.register('Command+Q', () => {
-            app.quit();
-        });
-    }
 
     app.on('activate', () => {
         if (BrowserWindow.getAllWindows().length === 0) {


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request

Welcome and thank you for your interest in contributing to our project.

## Guidelines

`  🗒️ `  Please read the [Contributing Guide](https://github.com/laradumps/app/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`  ✍️ `  Give this PR a meaningful title.

`  📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change

### Related Issue(s)

This PR Fixes the Issue https://github.com/laradumps/app/issues/129.

### Description

LaraDumps was hijacking the key press `⌘+Q` (app quit) from anywhere, even if not in focus. This means that I cannot use this shortcut in any other application while having LaraDumps opened.

In the image below, I am done with my work and want to close the text editor. When I press `⌘+Q` in the text editor, LaraDumps responds:

<img width="1234" alt="" src="https://user-images.githubusercontent.com/79267265/213908456-39e3a88c-f6b3-4f2b-8fcc-e017ca4e7d60.png">

With this PR, LaraDumps only listen to `⌘+Q` pressed within the app. It also adds `cmd+Q` for Linux and Windows.

![fix](https://user-images.githubusercontent.com/79267265/213908701-8c0a288a-0dae-4fdf-bdf9-780765a36972.png)

Resulting in:

<img width="1147" alt="" src="https://user-images.githubusercontent.com/79267265/213908639-54e93da4-d279-4b96-9ee2-87397aa91c78.png">


### Contribution Guide

- [X] I have read and followed the steps listed in the [Contributing Guide](https://github.com/laradumps/app/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
