### PR TITLE
Bugfix/281 blank screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "typescript": "*",
         "vue": "3.4.21",
         "vue-diff": "^1.2.4",
-        "vue-i18n": "9.10.2",
+        "vue-i18n": "9.4.1",
         "vue-json-pretty": "^2.4.0",
         "which": "^4.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "laradumps",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "private": false,
     "description": "LaraDumps a friendly app designed to boost your PHP coding and debugging experience. https://github.com/laradumps/app",
     "author": "Luan Freitas <luanfreitas10@protonmail.com>",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -207,6 +207,8 @@ function createWindow(): BrowserWindow {
         if (isDev) {
             win.webContents.openDevTools();
         }
+
+        win.webContents.openDevTools();
     });
 
     return win;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -207,8 +207,6 @@ function createWindow(): BrowserWindow {
         if (isDev) {
             win.webContents.openDevTools();
         }
-
-        win.webContents.openDevTools();
     });
 
     return win;

--- a/src/renderer/components/ThePackageUpdateInfo.vue
+++ b/src/renderer/components/ThePackageUpdateInfo.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup>
 import { ClipboardIcon } from "@heroicons/vue/24/outline";
 import { ref } from "vue";
 
@@ -10,7 +10,7 @@ window.ipcRenderer.on("ipc:package-down", (event, arg) => {
     setTimeout(() => modal.value.showModal(), 0)
 });
 
-function formatVersion(version: string) {
+function formatVersion(version) {
     if (typeof version == "undefined") {
         return;
     }
@@ -71,14 +71,14 @@ function formatVersion(version: string) {
                     </div>
                     <div class="mt-5">
                         <p>
-                            {{ $t("package_update_info.installed_version") }}
+                            LaraDumps Core: {{ $t("package_update_info.installed_version") }}
                             <span
                                 class="font-semibold"
                                 v-text="formatVersion(updateInfo.packageVersion)"
                             ></span>
                         </p>
                         <p>
-                            {{ $t("package_update_info.minimum_required_version") }}
+                            LaraDumps Core: {{ $t("package_update_info.minimum_required_version") }}
                             <span
                                 class="font-semibold"
                                 v-text="formatVersion(updateInfo.minPackageVersion)"

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,26 +271,26 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz"
   integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
 
-"@intlify/core-base@9.10.2":
-  version "9.10.2"
-  resolved "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.10.2.tgz"
-  integrity sha512-HGStVnKobsJL0DoYIyRCGXBH63DMQqEZxDUGrkNI05FuTcruYUtOAxyL3zoAZu/uDGO6mcUvm3VXBaHG2GdZCg==
+"@intlify/core-base@9.4.1":
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.4.1.tgz#5ab9b624a34af2299a9b45aa331b6516c169b8b5"
+  integrity sha512-WIwx+elsZbxSMxRG5+LC+utRohFvmZMoDevfKOfnYMLbpCjCSavqTfHJAtfsY6ruowzqXeKkeLhRHbYbjoJx5g==
   dependencies:
-    "@intlify/message-compiler" "9.10.2"
-    "@intlify/shared" "9.10.2"
+    "@intlify/message-compiler" "9.4.1"
+    "@intlify/shared" "9.4.1"
 
-"@intlify/message-compiler@9.10.2":
-  version "9.10.2"
-  resolved "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.10.2.tgz"
-  integrity sha512-ntY/kfBwQRtX5Zh6wL8cSATujPzWW2ZQd1QwKyWwAy5fMqJyyixHMeovN4fmEyCqSu+hFfYOE63nU94evsy4YA==
+"@intlify/message-compiler@9.4.1":
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.4.1.tgz#aa00629a455e23cece3464293834a02994b4fb04"
+  integrity sha512-aN2N+dUx320108QhH51Ycd2LEpZ+NKbzyQ2kjjhqMcxhHdxtOnkgdx+MDBhOy/CObwBmhC3Nygzc6hNlfKvPNw==
   dependencies:
-    "@intlify/shared" "9.10.2"
+    "@intlify/shared" "9.4.1"
     source-map-js "^1.0.2"
 
-"@intlify/shared@9.10.2":
-  version "9.10.2"
-  resolved "https://registry.npmjs.org/@intlify/shared/-/shared-9.10.2.tgz"
-  integrity sha512-ttHCAJkRy7R5W2S9RVnN9KYQYPIpV2+GiS79T4EE37nrPyH6/1SrOh3bmdCRC1T3ocL8qCDx7x2lBJ0xaITU7Q==
+"@intlify/shared@9.4.1":
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.4.1.tgz#bd0d221aaac476b6778a10ddcd0472f812c64e27"
+  integrity sha512-A51elBmZWf1FS80inf/32diO9DeXoqg9GR9aUDHFcfHoNDuT46Q+fpPOdj8jiJnSHSBh8E1E+6qWRhAZXdK3Ng==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -5409,13 +5409,13 @@ vue-eslint-parser@^9.4.2:
     lodash "^4.17.21"
     semver "^7.3.6"
 
-vue-i18n@9.10.2:
-  version "9.10.2"
-  resolved "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.10.2.tgz"
-  integrity sha512-ECJ8RIFd+3c1d3m1pctQ6ywG5Yj8Efy1oYoAKQ9neRdkLbuKLVeW4gaY5HPkD/9ssf1pOnUrmIFjx2/gkGxmEw==
+vue-i18n@9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-9.4.1.tgz#c7402662fe9b40b17798afffa9d8bfa4734dd7f5"
+  integrity sha512-vnQyYE9LBuNOqPpETIcCaGnAyLEqfeIvDcyZ9T+WBCWFTqWw1J8FuF1jfeDwpHBi5JKgAwgXyq1mt8jp/x/GPA==
   dependencies:
-    "@intlify/core-base" "9.10.2"
-    "@intlify/shared" "9.10.2"
+    "@intlify/core-base" "9.4.1"
+    "@intlify/shared" "9.4.1"
     "@vue/devtools-api" "^6.5.0"
 
 vue-json-pretty@^2.4.0:


### PR DESCRIPTION
The same problem related to the version of vue-i18n broke after version 9.4.1 (in the case of laradumps, I will investigate possible changes, but this is a breaking change outside of the major version).

To fix the problem, it was necessary to enable devTools and check for a problem with the console. The error: "Syntax Error" caused in the build: $t.t("...")

Related: https://github.com/laradumps/app/pull/267
Issue: https://github.com/laradumps/app/issues/281