### PR TITLE
Add Pause for subsequent requests - lock/unlock queries

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -388,10 +388,6 @@ nativeTheme.on("updated", () => {
     mainWindow.webContents.send(nativeTheme.shouldUseDarkColors ? "app:theme-dark" : "app:theme-light");
 });
 
-ipcMain.on("main:pause-dumps", (event, args) => {
-    mainWindow.webContents.send("app:pause-dumps", args);
-});
-
 ipcMain.on("platform", (event, args) => {
     event.reply("platform.reply", process.platform);
 });

--- a/src/renderer/components/ClearAll.vue
+++ b/src/renderer/components/ClearAll.vue
@@ -9,6 +9,7 @@ import { useQueriesPayloadStore } from "@/store/queries";
 import { useMailStore } from "@/store/mail";
 import { useJobStore } from "@/store/jobs";
 import { useLogStore } from "@/store/logs";
+import { usePendingRequestsStore } from "@/store/pending-requests";
 
 const timeStore = useTimeStore();
 const colorStore = useColorStore();
@@ -18,6 +19,7 @@ const logStore = useLogStore();
 const jobStore = useJobStore();
 const queryStore = useQueriesPayloadStore();
 const mailStore = useMailStore();
+const pendingRequestsStore = usePendingRequestsStore();
 
 const clearAll = (): void => {
     // store
@@ -30,6 +32,8 @@ const clearAll = (): void => {
     jobStore.clear();
     mailStore.clear();
     queryStore.clear();
+
+    pendingRequestsStore.clear("queries");
 };
 
 const hasPayload = computed(() => {

--- a/src/renderer/components/DumpItem.vue
+++ b/src/renderer/components/DumpItem.vue
@@ -58,52 +58,6 @@ onMounted(() => {
     }
 });
 
-const getColorClass = (colorType: string) => {
-    let borderClass = "";
-    let bgClass = "";
-
-    if (typeof props.payload.color !== "undefined") {
-        switch (props.payload.color) {
-            case "red":
-                borderClass = "!border-l-error";
-                bgClass = "!bg-error/10";
-                break;
-            case "orange":
-            case "warning":
-                borderClass = "!border-l-warning";
-                bgClass = "!bg-warning/10";
-                break;
-            case "green":
-                borderClass = "!border-l-success";
-                bgClass = "!bg-success/10";
-                break;
-            case "blue":
-                borderClass = "!border-l-info";
-                bgClass = "!bg-info/10";
-                break;
-            case "gray":
-                borderClass = "!border-l-neutral";
-                bgClass = "!bg-neutral/10";
-                break;
-            case "black":
-                borderClass = "!border-black";
-                bgClass = "!bg-black/10";
-                break;
-            default:
-                borderClass = props.payload.color;
-                bgClass = props.payload.color;
-                break;
-        }
-
-        return colorType === "border" ? borderClass : bgClass;
-    }
-
-    return props.payload.color;
-};
-
-const borderColor = computed(() => getColorClass("border"));
-const bgColor = computed(() => getColorClass("bg"));
-
 const isDuplicated = (sql) => {
     return duplicatesStore.duplicatesInfo.some((info) => info.request_id === timeStore.selected && info.sql === sql && info.has_duplicated);
 };

--- a/src/renderer/components/DumpItem.vue
+++ b/src/renderer/components/DumpItem.vue
@@ -21,12 +21,16 @@ import { useCollapse } from "@/store/collapse";
 import { useSettingsStore } from "@/store/settings";
 import moment from "moment";
 import { useScreenStore } from "@/store/screen";
+import { LockClosedIcon } from "@heroicons/vue/20/solid";
+import { useQueriesBlockedStore } from "@/store/queries-blocked";
+import tippy from "tippy.js";
 
 const duplicatesStore = useQueryDuplicated();
 const timeStore = useTimeStore();
 const collapseStore = useCollapse();
 const settingsStore = useSettingsStore();
 const screenStore = useScreenStore();
+const queriesBlockedStore = useQueriesBlockedStore();
 
 const open = ref(true);
 const openOptions = ref(false);
@@ -37,6 +41,12 @@ const props = defineProps<{
 
 const copyDump = () => {
     nextTick(() => {
+        if (props.payload.type === "queries" && props.payload.queries?.sql) {
+            navigator.clipboard.writeText(props.payload.queries?.sql).then(() => {});
+
+            return;
+        }
+
         const value = document.getElementById(`dump-content-${props.payload.sf_dump_id}`)?.innerText;
 
         navigator.clipboard.writeText(value).then(() => {});
@@ -96,6 +106,14 @@ const getLabel = computed(() => {
 
     return props.payload.type;
 });
+
+const block = () => {
+    props.payload.queries?.sql && queriesBlockedStore.toggle(props.payload.queries?.sql);
+};
+
+onMounted(() => {
+    tippy("[data-tippy-content]", { allowHTML: true, theme: "light-border", placement: "right-end" });
+});
 </script>
 <template>
     <div>
@@ -122,12 +140,13 @@ const getLabel = computed(() => {
                 <div class="group flex justify-center items-center gap-2">
                     <div
                         v-show="open"
-                        class="mr-1 group flex justify-center items-center gap-3 opacity-0 transition-all ease-in duration-300 group-hover:opacity-100"
+                        class="mr-1 flex justify-center items-center gap-3 opacity-0 transition-all ease-in duration-300 group-hover:opacity-100"
                     >
                         <div
                             v-if="!['table'].includes(screenStore.screen)"
-                            :title="$t('click_to_copy')"
                             @click.stop="copyDump"
+                            class="text-info"
+                            :data-tippy-content="$t('click_to_copy')"
                         >
                             <CopyToClick />
                         </div>
@@ -146,6 +165,15 @@ const getLabel = computed(() => {
                         :class="badgeClasses"
                     >
                         {{ getLabel }}
+                    </div>
+
+                    <div
+                        v-if="payload.queries && open"
+                        :data-tippy-content="$t('click_to_block')"
+                        @click.stop="block"
+                        class="opacity-0 transition-all group-hover:opacity-100"
+                    >
+                        <LockClosedIcon class="text-warning size-4 hover:opacity-75" />
                     </div>
 
                     <div

--- a/src/renderer/components/HeaderQueryRequests.vue
+++ b/src/renderer/components/HeaderQueryRequests.vue
@@ -12,8 +12,6 @@ const formattedQueriesStore = useFormattedQueriesStore();
 const duplicatesStore = useQueryDuplicated();
 const queriesOriginFilter = useQueriesOriginFilter();
 
-const orderBy = ref("default");
-
 const props = defineProps({
     total: {
         type: Number,
@@ -44,16 +42,6 @@ const allRequests = computed(() => {
 
     return requests;
 });
-
-watch(orderBy, (value) => {
-    timeStore.setOrder(value);
-});
-
-const options = ["http", "console"];
-
-const toggle = (value) => {
-    queriesOriginFilter.toggleFilter(value);
-};
 </script>
 
 <template>
@@ -100,74 +88,6 @@ const toggle = (value) => {
                         />
                         Prettify
                     </label>
-
-                    <div class="dropdown dropdown-end">
-                        <div
-                            tabindex="0"
-                            role="button"
-                            class="btn btn-sm btn-circle btn-soft"
-                        >
-                            <AdjustmentsHorizontalIcon class="w-4.5" />
-                        </div>
-                        <ul
-                            tabindex="0"
-                            class="dropdown-content menu !text-sm bg-base-300 rounded-box z-1 w-52 p-4 shadow-sm"
-                        >
-                            <li class="text-xs uppercase font-normal mb-1">Order by:</li>
-                            <li>
-                                <label>
-                                    <input
-                                        v-model="orderBy"
-                                        type="radio"
-                                        name="radio-order"
-                                        class="radio radio-sm"
-                                        value="default"
-                                    />
-                                    default
-                                </label>
-                            </li>
-                            <li>
-                                <label>
-                                    <input
-                                        v-model="orderBy"
-                                        type="radio"
-                                        name="radio-order"
-                                        class="radio radio-sm"
-                                        value="desc"
-                                    />
-                                    desc
-                                </label>
-                            </li>
-                            <li>
-                                <label>
-                                    <input
-                                        v-model="orderBy"
-                                        type="radio"
-                                        name="radio-order"
-                                        class="radio radio-sm"
-                                        value="asc"
-                                    />
-                                    asc
-                                </label>
-                            </li>
-                            <li class="text-xs uppercase font-normal my-3">origin:</li>
-                            <li
-                                v-for="option in options"
-                                :key="option"
-                            >
-                                <label>
-                                    <input
-                                        type="checkbox"
-                                        :value="option"
-                                        :checked="queriesOriginFilter.origin.includes(option)"
-                                        @change="toggle(option)"
-                                        class="checkbox checkbox-sm"
-                                    />
-                                    {{ option.charAt(0).toUpperCase() + option.slice(1) }}
-                                </label>
-                            </li>
-                        </ul>
-                    </div>
                 </div>
             </div>
         </div>

--- a/src/renderer/components/HeaderQueryRequests.vue
+++ b/src/renderer/components/HeaderQueryRequests.vue
@@ -1,11 +1,10 @@
 <script setup>
 import { useTimeStore } from "@/store/time";
 import SelectMenu from "@/components/SelectMenu.vue";
-import { computed, ref, watch } from "vue";
+import { computed } from "vue";
 import { useFormattedQueriesStore } from "@/store/formatted-queries";
 import { useQueryDuplicated } from "@/store/query-duplicated";
 import { useQueriesOriginFilter } from "@/store/queries-origin-filter.js";
-import { AdjustmentsHorizontalIcon } from "@heroicons/vue/20/solid";
 
 const timeStore = useTimeStore();
 const formattedQueriesStore = useFormattedQueriesStore();
@@ -50,18 +49,18 @@ const allRequests = computed(() => {
             v-if="timeStore.groups.length > 0"
             class="justify-between items-center gap-4 text-base-content"
         >
-            <div class="flex justify-between my-1">
+            <div class="flex justify-between my-1 uppercase">
                 <div class="flex w-full items-center">
                     <div class="flex flex-row-reverse gap-3 items-center">
                         <span class="text-primary text-base whitespace-nowrap">{{ timeStore.get(timeStore.selected)?.total.toFixed(2) }} ms</span>
-                        <span class="text-xs uppercase">time</span>
+                        <span class="text-xs">time</span>
                     </div>
 
                     <div class="divider divider-horizontal !mx-1.5"></div>
 
                     <div class="flex flex-row-reverse gap-3 items-center">
                         <span class="text-primary text-base whitespace-nowrap">{{ totalFiltered }}</span>
-                        <span class="text-xs uppercase">queries</span>
+                        <span class="text-xs">queries</span>
                     </div>
 
                     <div

--- a/src/renderer/components/Icons/IconCollapseClose.vue
+++ b/src/renderer/components/Icons/IconCollapseClose.vue
@@ -1,7 +1,7 @@
 <template>
     <svg
         stroke="currentColor"
-        class="h-3.5"
+        class="h-4"
         fill="none"
         viewBox="0 0 24 24"
     >

--- a/src/renderer/components/Icons/IconCollapseOpen.vue
+++ b/src/renderer/components/Icons/IconCollapseOpen.vue
@@ -1,7 +1,7 @@
 <template>
     <svg
         stroke="currentColor"
-        class="h-3.5"
+        class="h-4"
         fill="none"
         viewBox="0 0 24 24"
     >

--- a/src/renderer/components/NavBarPause.vue
+++ b/src/renderer/components/NavBarPause.vue
@@ -1,17 +1,9 @@
 <script setup>
-import { onMounted, ref } from "vue";
 import IconPause from "@/components/Icons/IconPause.vue";
 import IconPlay from "@/components/Icons/IconPlay.vue";
+import { usePausePayloadStore } from "@/store/pause.js";
 
-const isPaused = ref(false);
-
-onMounted(() => {});
-
-const togglePause = () => {
-    isPaused.value = !isPaused.value;
-
-    window.ipcRenderer.send("main:pause-dumps", isPaused.value);
-};
+const pauseStore = usePausePayloadStore();
 </script>
 
 <template>
@@ -19,9 +11,9 @@ const togglePause = () => {
         <button
             :title="$t('pause')"
             class="p-2 hover:bg-base-200 rounded-md"
-            @click="togglePause()"
+            @click="pauseStore.toggle()"
         >
-            <IconPause v-if="!isPaused" />
+            <IconPause v-if="!pauseStore.is_paused" />
             <IconPlay
                 v-else
                 class="size-4 text-warning"

--- a/src/renderer/components/TheNavBar.vue
+++ b/src/renderer/components/TheNavBar.vue
@@ -67,7 +67,7 @@ const xDebugMode = computed(() => {
             <NavBarGlobalSearch v-if="payloadStore.payload.length > 0" />
 
             <!-- collapse -->
-            <NavBarCollapse v-if="settingsStore.settings.show_collapse_button && payloadStore.payload.length > 0" />
+            <NavBarCollapse v-if="settingsStore.settings.show_collapse_button" />
 
             <!-- always on top -->
             <NavBarAlwaysOnTop />

--- a/src/renderer/components/laravel/JobView.vue
+++ b/src/renderer/components/laravel/JobView.vue
@@ -2,7 +2,7 @@
 import { Job, useJobStore } from "@/store/jobs";
 import { computed, defineProps, nextTick, ref } from "vue";
 import moment from "moment";
-import { EyeIcon } from "@heroicons/vue/24/outline";
+import { EyeIcon, MagnifyingGlassIcon } from "@heroicons/vue/24/outline";
 import { CheckIcon, XMarkIcon, ArrowPathIcon, InformationCircleIcon } from "@heroicons/vue/24/solid";
 import { TrashIcon } from "@heroicons/vue/24/outline";
 
@@ -154,18 +154,21 @@ const duration = (startTime: any, endTime: any) => {
             :class="{ 'h-[calc(100vh-100px)]': inScreenWindow, 'h-[calc(100vh-150px)]': !inScreenWindow }"
         >
             <div class="flex items-center gap-2 justify-between mt-1">
-                <input
-                    v-model="search"
-                    type="text"
-                    class="w-full input input-sm"
-                    :placeholder="$t('search')"
-                />
+                <label class="input w-full input-sm">
+                    <MagnifyingGlassIcon class="size-4" />
+                    <input
+                        v-model="search"
+                        type="search"
+                        class="grow"
+                        :placeholder="$t('search')"
+                    />
+                </label>
                 <button
                     @click="clear()"
                     class="btn btn-soft btn-sm"
+                    data-tippy-content="Clear"
                 >
-                    <TrashIcon class="w-4" />
-                    <span class="text-xs">{{ $t("clear") }}</span>
+                    <TrashIcon class="w-4 text-error" />
                 </button>
             </div>
 

--- a/src/renderer/components/laravel/LogView.vue
+++ b/src/renderer/components/laravel/LogView.vue
@@ -2,7 +2,7 @@
 import { computed, defineProps, nextTick, onMounted, ref } from "vue";
 import moment from "moment";
 import { EyeIcon, TrashIcon } from "@heroicons/vue/24/outline";
-import { ExclamationCircleIcon, ExclamationTriangleIcon, InformationCircleIcon } from "@heroicons/vue/24/outline";
+import { ExclamationCircleIcon, MagnifyingGlassIcon, ExclamationTriangleIcon, InformationCircleIcon } from "@heroicons/vue/24/outline";
 
 import { IdeHandle } from "@/types/IdeHandle";
 import { useCurrentProject } from "@/store/current-project";
@@ -146,21 +146,24 @@ const closeModal = () => {
             :class="{ 'h-[calc(100vh-100px)]': inScreenWindow, 'h-[calc(100vh-150px)]': !inScreenWindow }"
         >
             <div class="flex items-center gap-2 justify-between mt-1">
-                <input
-                    v-model="search"
-                    type="text"
-                    class="w-full input input-sm"
-                    :placeholder="$t('search')"
-                />
+                <label class="input w-full input-sm">
+                    <MagnifyingGlassIcon class="size-4" />
+                    <input
+                        v-model="search"
+                        type="search"
+                        class="grow"
+                        :placeholder="$t('search')"
+                    />
+                </label>
                 <div class="flex items-center justify-center">
                     <HeaderColorsFilter has-color="has-color" />
                 </div>
                 <button
                     @click="clear()"
                     class="btn btn-soft btn-sm"
+                    data-tippy-content="Clear"
                 >
-                    <TrashIcon class="w-4" />
-                    <span class="text-xs">{{ $t("clear") }}</span>
+                    <TrashIcon class="w-4 text-error" />
                 </button>
             </div>
 

--- a/src/renderer/components/laravel/MailView.vue
+++ b/src/renderer/components/laravel/MailView.vue
@@ -4,7 +4,7 @@ import "splitpanes/dist/splitpanes.css";
 import { Attachment, Mail, mimeTypeMap, useMailStore } from "@/store/mail";
 import moment from "moment";
 import { computed, defineProps, nextTick, ref } from "vue";
-import { CloudArrowDownIcon, TrashIcon, DevicePhoneMobileIcon, DeviceTabletIcon, ComputerDesktopIcon } from "@heroicons/vue/24/outline";
+import { CloudArrowDownIcon, TrashIcon, DevicePhoneMobileIcon, DeviceTabletIcon, ComputerDesktopIcon, MagnifyingGlassIcon } from "@heroicons/vue/24/outline";
 import IconExternalLink from "@/components/Icons/IconExternalLink.vue";
 import DumpLink from "@/components/DumpLink.vue";
 import { modifyHtml } from "./../utils";
@@ -192,18 +192,21 @@ const setPreviewMode = (mode: string) => {
 
         <div class="space-y-3 h-[calc(100vh-140px)]">
             <div class="mt-1 flex items-center gap-2 justify-between">
-                <input
-                    v-model="search"
-                    type="text"
-                    class="w-full input input-sm"
-                    :placeholder="$t('search')"
-                />
+                <label class="input w-full input-sm">
+                    <MagnifyingGlassIcon class="size-4" />
+                    <input
+                        v-model="search"
+                        type="search"
+                        class="grow"
+                        :placeholder="$t('search')"
+                    />
+                </label>
                 <button
                     @click="clear()"
                     class="btn btn-soft btn-sm"
+                    data-tippy-content="Clear"
                 >
-                    <TrashIcon class="w-4" />
-                    <span class="text-xs">{{ $t("clear") }}</span>
+                    <TrashIcon class="w-4 text-error" />
                 </button>
             </div>
 

--- a/src/renderer/components/laravel/QueriesView.vue
+++ b/src/renderer/components/laravel/QueriesView.vue
@@ -1,19 +1,24 @@
 <script setup lang="ts">
 import { Payload } from "@/types/Payload";
 import HeaderQueryRequests from "@/components/HeaderQueryRequests.vue";
-import { computed, defineProps, ref } from "vue";
+import { computed, defineProps, onMounted, ref, watch } from "vue";
 import { useQueriesPayloadStore } from "@/store/queries";
 import { useTimeStore } from "@/store/time";
 import DumpItem from "@/components/DumpItem.vue";
 import { useQueryDuplicated } from "@/store/query-duplicated";
 import { useQueriesOriginFilter } from "@/store/queries-origin-filter";
-import { TrashIcon } from "@heroicons/vue/24/outline";
+import { useQueriesBlockedStore } from "@/store/queries-blocked";
+import { AdjustmentsHorizontalIcon, MagnifyingGlassIcon, TrashIcon, LockClosedIcon, LockOpenIcon } from "@heroicons/vue/20/solid";
+import tippy from "tippy.js";
 
 const queriesStore = useQueriesPayloadStore();
 const timeStore = useTimeStore();
 const queriesOriginFilter = useQueriesOriginFilter();
+const blockedQueriesStore = useQueriesBlockedStore();
+const queryDuplicatedStore = useQueryDuplicated();
 
 const search = ref("");
+const orderBy = ref("default");
 
 const props = defineProps<{
     items: [];
@@ -71,25 +76,181 @@ const queries = computed(() => {
 const clear = () => {
     timeStore.clear();
     queriesStore.clear();
+    queriesOriginFilter.clear();
+    blockedQueriesStore.clear();
+    queryDuplicatedStore.clear();
 };
+
+const showBlockedQueries = () => {
+    blocked_queries.showModal();
+};
+
+watch(orderBy, (value) => {
+    timeStore.setOrder(value);
+});
+
+const options = ["http", "console"];
+
+const toggle = (value) => {
+    queriesOriginFilter.toggleFilter(value);
+};
+
+onMounted(() => {
+    tippy("[data-tippy-content]", { allowHTML: true, theme: "light-border", placement: "right-end" });
+});
 </script>
 
 <template>
     <div class="px-3">
-        <div class="flex items-center gap-2 justify-between mt-1 mb-2">
-            <input
-                v-model="search"
-                type="text"
-                class="w-full input input-sm"
-                :placeholder="$t('search')"
-            />
-            <button
-                @click="clear()"
-                class="btn btn-soft btn-sm"
+        <dialog
+            id="blocked_queries"
+            class="modal modal-middle"
+        >
+            <div class="modal-box w-11/12 max-w-5xl">
+                <h3 class="font-bold text-lg">Blocked</h3>
+                <div class="overflow-auto mt-3 h-[calc(100vh-240px)]">
+                    <table class="table table-zebra w-full">
+                        <thead>
+                            <tr>
+                                <th>sql</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr
+                                v-for="(sql, index) in blockedQueriesStore.blocked"
+                                :key="index"
+                            >
+                                <td>
+                                    <span
+                                        :title="sql"
+                                        class="line-clamp-4"
+                                        >{{ sql }}</span
+                                    >
+                                </td>
+                                <td>
+                                    <button
+                                        @click="blockedQueriesStore.unblock(sql)"
+                                        class="btn btn-primary btn-sm"
+                                    >
+                                        <LockOpenIcon class="w-4" />
+                                        {{ $t("unblock") }}
+                                    </button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <form
+                method="dialog"
+                class="modal-backdrop"
             >
-                <TrashIcon class="w-4" />
-                <span class="text-xs">{{ $t("clear") }}</span>
-            </button>
+                <button>close</button>
+            </form>
+        </dialog>
+
+        <div class="flex items-center gap-2 justify-between mt-1 mb-2">
+            <div class="flex gap-2 w-full">
+                <label class="input w-full input-sm">
+                    <MagnifyingGlassIcon class="size-4" />
+                    <input
+                        v-model="search"
+                        type="search"
+                        class="grow"
+                        :placeholder="$t('search')"
+                    />
+                </label>
+            </div>
+            <div class="flex gap-2">
+                <div class="dropdown dropdown-end">
+                    <div
+                        tabindex="0"
+                        role="button"
+                        class="btn btn-soft btn-sm"
+                    >
+                        <AdjustmentsHorizontalIcon class="w-4.5 text-primary" />
+                    </div>
+                    <ul
+                        tabindex="0"
+                        class="dropdown-content menu !text-sm bg-base-300 rounded-box z-1 w-52 p-4 shadow-sm"
+                    >
+                        <li class="text-xs uppercase font-normal mb-1">Order by:</li>
+                        <li>
+                            <label>
+                                <input
+                                    v-model="orderBy"
+                                    type="radio"
+                                    name="radio-order"
+                                    class="radio radio-sm"
+                                    value="default"
+                                />
+                                default
+                            </label>
+                        </li>
+                        <li>
+                            <label>
+                                <input
+                                    v-model="orderBy"
+                                    type="radio"
+                                    name="radio-order"
+                                    class="radio radio-sm"
+                                    value="desc"
+                                />
+                                desc
+                            </label>
+                        </li>
+                        <li>
+                            <label>
+                                <input
+                                    v-model="orderBy"
+                                    type="radio"
+                                    name="radio-order"
+                                    class="radio radio-sm"
+                                    value="asc"
+                                />
+                                asc
+                            </label>
+                        </li>
+                        <li class="text-xs uppercase font-normal my-3">origin:</li>
+                        <li
+                            v-for="option in options"
+                            :key="option"
+                        >
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    :value="option"
+                                    :checked="queriesOriginFilter.origin.includes(option)"
+                                    @change="toggle(option)"
+                                    class="checkbox checkbox-sm"
+                                />
+                                {{ option.charAt(0).toUpperCase() + option.slice(1) }}
+                            </label>
+                        </li>
+                    </ul>
+                </div>
+                <button
+                    @click="showBlockedQueries"
+                    class="btn btn-soft btn-sm"
+                    data-tippy-content="Blocked Queries"
+                >
+                    <LockClosedIcon class="text-warning size-4 hover:opacity-75" />
+                    <span
+                        class="text-xs font-normal opacity-70"
+                        v-if="blockedQueriesStore.blocked.length > 0"
+                    >
+                        ({{ blockedQueriesStore.blocked.length }})
+                    </span>
+                </button>
+                <button
+                    @click="clear()"
+                    class="btn btn-soft btn-sm"
+                    data-tippy-content="Clear"
+                >
+                    <TrashIcon class="w-4 text-error" />
+                </button>
+            </div>
         </div>
 
         <HeaderQueryRequests

--- a/src/renderer/components/laravel/QueriesView.vue
+++ b/src/renderer/components/laravel/QueriesView.vue
@@ -83,6 +83,8 @@ const clear = () => {
     queryDuplicatedStore.clear();
 
     pendingRequestsStore.clear("queries");
+
+    window.ipcRenderer.send('reload')
 };
 
 const showBlockedQueries = () => {

--- a/src/renderer/components/laravel/QueriesView.vue
+++ b/src/renderer/components/laravel/QueriesView.vue
@@ -10,12 +10,14 @@ import { useQueriesOriginFilter } from "@/store/queries-origin-filter";
 import { useQueriesBlockedStore } from "@/store/queries-blocked";
 import { AdjustmentsHorizontalIcon, MagnifyingGlassIcon, TrashIcon, LockClosedIcon, LockOpenIcon } from "@heroicons/vue/20/solid";
 import tippy from "tippy.js";
+import { usePendingRequestsStore } from "@/store/pending-requests";
 
 const queriesStore = useQueriesPayloadStore();
 const timeStore = useTimeStore();
 const queriesOriginFilter = useQueriesOriginFilter();
 const blockedQueriesStore = useQueriesBlockedStore();
 const queryDuplicatedStore = useQueryDuplicated();
+const pendingRequestsStore = usePendingRequestsStore();
 
 const search = ref("");
 const orderBy = ref("default");
@@ -79,6 +81,8 @@ const clear = () => {
     queriesOriginFilter.clear();
     blockedQueriesStore.clear();
     queryDuplicatedStore.clear();
+
+    pendingRequestsStore.clear("queries");
 };
 
 const showBlockedQueries = () => {

--- a/src/renderer/lang/al-AL.js
+++ b/src/renderer/lang/al-AL.js
@@ -108,5 +108,7 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block",
+    unblock: "Unblock"
 };

--- a/src/renderer/lang/ar-AR.js
+++ b/src/renderer/lang/ar-AR.js
@@ -108,5 +108,6 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block"
 };

--- a/src/renderer/lang/en.js
+++ b/src/renderer/lang/en.js
@@ -107,5 +107,7 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block",
+    unblock: "Unblock"
 };

--- a/src/renderer/lang/es-ES.js
+++ b/src/renderer/lang/es-ES.js
@@ -109,5 +109,7 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block",
+    unblock: "Unblock"
 };

--- a/src/renderer/lang/fa-IR.js
+++ b/src/renderer/lang/fa-IR.js
@@ -108,5 +108,7 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block",
+    unblock: "Unblock"
 };

--- a/src/renderer/lang/id-ID.js
+++ b/src/renderer/lang/id-ID.js
@@ -108,5 +108,7 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block",
+    unblock: "Unblock"
 };

--- a/src/renderer/lang/it-IT.js
+++ b/src/renderer/lang/it-IT.js
@@ -109,5 +109,7 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block",
+    unblock: "Unblock"
 };

--- a/src/renderer/lang/pt-BR.js
+++ b/src/renderer/lang/pt-BR.js
@@ -106,5 +106,7 @@ export default {
         connect: "Connect"
     },
     search: "Buscar",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App requer laradumps/laradumps-core 3.0 ou superior",
+    click_to_block: "Click para bloquear",
+    unblock: "Desbloquear"
 };

--- a/src/renderer/lang/tr-TR.js
+++ b/src/renderer/lang/tr-TR.js
@@ -108,5 +108,7 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block",
+    unblock: "Unblock"
 };

--- a/src/renderer/lang/zh-CN.js
+++ b/src/renderer/lang/zh-CN.js
@@ -108,5 +108,7 @@ export default {
         connect: "Connect"
     },
     search: "Search",
-    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher"
+    composer_invalid_version: "App require laradumps/laradumps-core 3.0 or higher",
+    click_to_block: "Click to block",
+    unblock: "Unblock"
 };

--- a/src/renderer/store/pause.ts
+++ b/src/renderer/store/pause.ts
@@ -1,0 +1,16 @@
+import { defineStore } from "pinia";
+
+type Current = {
+    is_paused: boolean;
+};
+
+export const usePausePayloadStore = defineStore("pausePayload", {
+    state: (): Current => ({
+        is_paused: false
+    }),
+    actions: {
+        toggle() {
+            this.is_paused = !this.is_paused;
+        }
+    }
+});

--- a/src/renderer/store/pause.ts
+++ b/src/renderer/store/pause.ts
@@ -1,11 +1,11 @@
 import { defineStore } from "pinia";
 
-type Current = {
+type State = {
     is_paused: boolean;
 };
 
 export const usePausePayloadStore = defineStore("pausePayload", {
-    state: (): Current => ({
+    state: (): State => ({
         is_paused: false
     }),
     actions: {

--- a/src/renderer/store/pending-requests.ts
+++ b/src/renderer/store/pending-requests.ts
@@ -1,0 +1,38 @@
+import { defineStore } from "pinia";
+
+type PendingRequest = {
+    [key: string]: any;
+};
+
+type State = {
+    pendingRequests: Record<string, Record<string, PendingRequest>>;
+};
+
+export const usePendingRequestsStore = defineStore("pendingRequests", {
+    state: (): State => ({
+        pendingRequests: {}
+    }),
+
+    actions: {
+        add(type: "queries", requestId: string, content: any) {
+            if (!this.pendingRequests[type]) {
+                this.pendingRequests[type] = {};
+            }
+            this.pendingRequests[type][requestId] = content;
+        },
+
+        has(type: "queries", requestId: string): boolean {
+            return !!this.pendingRequests[type]?.[requestId];
+        },
+
+        get(type: "queries", requestId: string): any | undefined {
+            return this.pendingRequests[type]?.[requestId] ?? null;
+        },
+
+        clear(type: "queries") {
+            if (this.pendingRequests[type]) {
+                delete this.pendingRequests[type];
+            }
+        }
+    }
+});

--- a/src/renderer/store/queries-blocked.ts
+++ b/src/renderer/store/queries-blocked.ts
@@ -1,0 +1,26 @@
+import { defineStore } from "pinia";
+
+type State = {
+    blocked: string[];
+};
+
+export const useQueriesBlockedStore = defineStore("queriesBlocked", {
+    state: (): State => ({
+        blocked: JSON.parse(localStorage.getItem("blocked") || "[]")
+    }),
+    actions: {
+        toggle(sql: string) {
+            this.blocked = this.blocked.includes(sql) ? this.blocked.filter((item) => item !== sql) : [...this.blocked, sql];
+
+            localStorage.setItem("blocked", JSON.stringify(this.blocked));
+        },
+        unblock(sql: string) {
+            this.blocked = this.blocked.filter((item) => item !== sql);
+            localStorage.setItem("blocked", JSON.stringify(this.blocked));
+        },
+        clear() {
+            this.blocked = [];
+            localStorage.removeItem("blocked");
+        }
+    }
+});

--- a/src/renderer/store/queries-origin-filter.ts
+++ b/src/renderer/store/queries-origin-filter.ts
@@ -16,6 +16,9 @@ export const useQueriesOriginFilter = defineStore("queriesOriginFilter", {
             } else {
                 this.origin.splice(index, 1);
             }
+        },
+        clear() {
+            this.origin = [];
         }
     }
 });

--- a/src/renderer/store/queries.ts
+++ b/src/renderer/store/queries.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { Payload } from "@/types/Payload";
 import { useSettingsStore } from "@/store/settings";
+import { useQueriesBlockedStore } from "@/store/queries-blocked";
 
 type State = {
     payload: Payload[];
@@ -12,6 +13,11 @@ export const useQueriesPayloadStore = defineStore("queriesPayload", {
     }),
     actions: {
         add(payload: Payload) {
+            const queriesBlockedStore = useQueriesBlockedStore();
+            if (queriesBlockedStore.blocked.includes(payload.queries.sql)) {
+                return;
+            }
+
             this._removeOldestIfExceedsLimit();
             this.payload.push(payload);
         },

--- a/src/renderer/store/query-duplicated.ts
+++ b/src/renderer/store/query-duplicated.ts
@@ -35,6 +35,10 @@ export const useQueryDuplicated = defineStore("queryDuplicated", {
             this.cache[request_id] = total;
 
             return total;
+        },
+        clear() {
+            this.duplicatesInfo = [];
+            this.cache = [];
         }
     }
 });

--- a/src/renderer/views/HomeView.vue
+++ b/src/renderer/views/HomeView.vue
@@ -31,6 +31,7 @@ import { deepClone } from "@/lib/deep_clone";
 import { usePausePayloadStore } from "@/store/pause";
 import tippy from "tippy.js";
 import { useQueriesBlockedStore } from "@/store/queries-blocked";
+import { usePendingRequestsStore } from "@/store/pending-requests";
 
 markRaw(TheUpdateModalInfo);
 
@@ -44,12 +45,13 @@ const settingsStore = useSettingsStore();
 const logStore = useLogStore();
 const queriesStore = useQueriesPayloadStore();
 const pausePayloadStore = usePausePayloadStore();
-const queriesBlockStore = useQueriesBlockedStore();
 
 const { locale } = useI18n({ useScope: "global" });
 const localeStore = useI18nStore();
 const jobStore = useJobStore();
 const mailStore = useMailStore();
+const pendingRequestsStore = usePendingRequestsStore();
+const blockedStore = useQueriesBlockedStore();
 
 const defaultScreen = ref({
     screen_name: "home",
@@ -68,14 +70,6 @@ const queriesScreen = ref([]);
 
 const applicationPath = ref("");
 const livewireRequests = ref([]);
-
-type PendingRequests = {
-    [requestId: string]: {
-        queries: string[];
-    };
-};
-
-const pendingRequests = ref<PendingRequests>({});
 
 const xdebugMode = ref(false);
 
@@ -314,19 +308,13 @@ const dumpListeners = () => {
         }
 
         const requestId = content.request_id;
+        const sqlQuery = content.queries.sql;
 
-        if (!pendingRequests.value[requestId]) {
-            pendingRequests.value[requestId] = {
-                queries: []
-            };
-        }
+        pendingRequestsStore.add(requestId, "queries", sqlQuery);
 
-        pendingRequests.value[requestId].queries.push(content.queries.sql);
+        const storedQuery = pendingRequestsStore.get(requestId, "queries");
 
-        const blockedStore = useQueriesBlockedStore();
-        const allBlocked = pendingRequests.value[requestId].queries.every((sql) => blockedStore.blocked.includes(sql));
-
-        if (allBlocked) {
+        if (blockedStore.blocked.includes(storedQuery)) {
             console.log(`all sql queries are blocked for request id ${requestId}`);
             return;
         }
@@ -339,14 +327,11 @@ const dumpListeners = () => {
 
         if (content.to_screen.new_window) {
             screenStore.hidden(content.to_screen.screen_name);
-
             window.ipcRenderer.send("screen-window:show", {
                 screen: content.to_screen.screen_name,
                 queries: serializable
             });
-        }
-
-        if (content.to_screen && !content.to_screen.new_window) {
+        } else {
             window.ipcRenderer.send("send-screen-window-update", {
                 screen: content.to_screen.screen_name,
                 queries: serializable

--- a/src/renderer/views/HomeView.vue
+++ b/src/renderer/views/HomeView.vue
@@ -29,6 +29,8 @@ import { useQueriesPayloadStore } from "@/store/queries";
 import QueriesView from "@/components/laravel/QueriesView.vue";
 import { deepClone } from "@/lib/deep_clone";
 import { usePausePayloadStore } from "@/store/pause";
+import tippy from "tippy.js";
+import { useQueriesBlockedStore } from "@/store/queries-blocked";
 
 markRaw(TheUpdateModalInfo);
 
@@ -42,6 +44,7 @@ const settingsStore = useSettingsStore();
 const logStore = useLogStore();
 const queriesStore = useQueriesPayloadStore();
 const pausePayloadStore = usePausePayloadStore();
+const queriesBlockStore = useQueriesBlockedStore();
 
 const { locale } = useI18n({ useScope: "global" });
 const localeStore = useI18nStore();
@@ -65,6 +68,14 @@ const queriesScreen = ref([]);
 
 const applicationPath = ref("");
 const livewireRequests = ref([]);
+
+type PendingRequests = {
+    [requestId: string]: {
+        queries: string[];
+    };
+};
+
+const pendingRequests = ref<PendingRequests>({});
 
 const xdebugMode = ref(false);
 
@@ -302,6 +313,24 @@ const dumpListeners = () => {
             return;
         }
 
+        const requestId = content.request_id;
+
+        if (!pendingRequests.value[requestId]) {
+            pendingRequests.value[requestId] = {
+                queries: []
+            };
+        }
+
+        pendingRequests.value[requestId].queries.push(content.queries.sql);
+
+        const blockedStore = useQueriesBlockedStore();
+        const allBlocked = pendingRequests.value[requestId].queries.every((sql) => blockedStore.blocked.includes(sql));
+
+        if (allBlocked) {
+            console.log(`all sql queries are blocked for request id ${requestId}`);
+            return;
+        }
+
         content.queries && timeStore.increment(content.request_id, content.id, content.queries);
 
         queriesStore.add(content);
@@ -325,11 +354,6 @@ const dumpListeners = () => {
         }
 
         addScreen(content.to_screen);
-
-        setTimeout(() => {
-            const lastPayload: Payload = payloadStore.filteredPayload[payloadStore.filteredPayload.length - 1];
-            if (lastPayload) timeStore.selected = lastPayload.request_id;
-        }, 50);
     });
 
     window.ipcRenderer.on("time_track", (event, { content }) => {

--- a/src/renderer/views/HomeView.vue
+++ b/src/renderer/views/HomeView.vue
@@ -28,6 +28,7 @@ import IconExternalLink from "@/components/Icons/IconExternalLink.vue";
 import { useQueriesPayloadStore } from "@/store/queries";
 import QueriesView from "@/components/laravel/QueriesView.vue";
 import { deepClone } from "@/lib/deep_clone";
+import { usePausePayloadStore } from "@/store/pause";
 
 markRaw(TheUpdateModalInfo);
 
@@ -40,6 +41,7 @@ const payloadStore = usePayloadStore();
 const settingsStore = useSettingsStore();
 const logStore = useLogStore();
 const queriesStore = useQueriesPayloadStore();
+const pausePayloadStore = usePausePayloadStore();
 
 const { locale } = useI18n({ useScope: "global" });
 const localeStore = useI18nStore();
@@ -63,7 +65,6 @@ const queriesScreen = ref([]);
 
 const applicationPath = ref("");
 const livewireRequests = ref([]);
-const isPaused = ref(false);
 
 const xdebugMode = ref(false);
 
@@ -104,8 +105,6 @@ onMounted(() => {
     }
 
     addScreen(defaultScreen.value);
-
-    window.ipcRenderer.on("app:pause-dumps", (event, arg) => (isPaused.value = arg));
 
     window.ipcRenderer.on("dump", (event, { content }) => dispatch(content));
 
@@ -174,11 +173,19 @@ onMounted(() => {
 
 const dumpListeners = () => {
     window.ipcRenderer.on("livewire", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         livewireRequests.value.push(content);
         dispatch(content);
     });
 
     window.ipcRenderer.on("jobs", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         jobStore.addOrUpdateJob(content.jobs, content.ide_handle);
 
         const serializableJobs = deepClone(jobStore.jobs);
@@ -206,18 +213,33 @@ const dumpListeners = () => {
     window.ipcRenderer.on("html", (event, { content }) => dispatch(content));
     window.ipcRenderer.on("mailable", (event, { content }) => dispatch(content));
     window.ipcRenderer.on("table_v2", (event, { content }) => dispatch(content));
+    window.ipcRenderer.on("table", (event, { content }) => dispatch(content));
+    window.ipcRenderer.on("http-client", (event, { content }) => dispatch(content));
+    window.ipcRenderer.on("model", (event, { content }) => dispatch(content));
+    window.ipcRenderer.on("json", (event, { content }) => dispatch(content));
+    window.ipcRenderer.on("query", (event, { content }) => dispatch(content));
+
     window.ipcRenderer.on("mail", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         mailStore.addOrUpdateMail(content.mail, content.ide_handle);
     });
 
     window.ipcRenderer.on("label", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         payloadStore.updateLabelPayload(content);
     });
 
-    window.ipcRenderer.on("table", (event, { content }) => dispatch(content));
-    window.ipcRenderer.on("http-client", (event, { content }) => dispatch(content));
-    window.ipcRenderer.on("model", (event, { content }) => dispatch(content));
     window.ipcRenderer.on("log_application", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         logStore.add(content);
 
         const serializable = deepClone(logStore.logs);
@@ -239,9 +261,17 @@ const dumpListeners = () => {
         }
     });
     window.ipcRenderer.on("color", async (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         payloadStore.updateColorPayload(content);
     });
     window.ipcRenderer.on("screen", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         payloadStore.updateScreenPayload(content);
         const screen: ScreenPayload = content.to_screen;
         addScreen(screen);
@@ -252,15 +282,26 @@ const dumpListeners = () => {
     });
 
     window.ipcRenderer.on("json_validate", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         payloadStore.updateJSONValidatePayload(content);
     });
 
     window.ipcRenderer.on("validate", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         payloadStore.updateValidatePayload(content);
     });
-    window.ipcRenderer.on("json", (event, { content }) => dispatch(content));
 
     window.ipcRenderer.on("queries", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         content.queries && timeStore.increment(content.request_id, content.id, content.queries);
 
         queriesStore.add(content);
@@ -290,8 +331,12 @@ const dumpListeners = () => {
             if (lastPayload) timeStore.selected = lastPayload.request_id;
         }, 50);
     });
-    window.ipcRenderer.on("query", (event, { content }) => dispatch(content));
+
     window.ipcRenderer.on("time_track", (event, { content }) => {
+        if (pausePayloadStore.is_paused) {
+            return;
+        }
+
         const exist = payloadStore.payload.filter((globalPayload: Payload) => globalPayload.with_label.label === content.with_label.label);
 
         if (exist.length === 0) {
@@ -352,7 +397,7 @@ const toggleScreen = async (value: string, shouldActivate = false): Promise<void
 };
 
 const dispatch = (content: any): void => {
-    if (isPaused.value) {
+    if (pausePayloadStore.is_paused) {
         return;
     }
 


### PR DESCRIPTION
If you are using [filament](https://github.com/filamentphp/filament) with LaraDumps, you can hardly debug "real" queries without the internal poll interfering with them. So you can block these queries and then unblock them.

Also, I fixed the global pause and click to copy buttons

![SCR-20250329-jywr](https://github.com/user-attachments/assets/d5e4351a-8756-4795-ab66-770f8d996271)
![SCR-20250329-jyxx](https://github.com/user-attachments/assets/5f3fa5f0-9faf-439a-b451-3f00d33d9698)

---
![image](https://github.com/user-attachments/assets/a742bc44-af4f-4d6e-8e84-67e79de82061)

