### PR TITLE
feat: add delayed screen toggle functionality

### DIFF
--- a/src/renderer/views/HomeView.vue
+++ b/src/renderer/views/HomeView.vue
@@ -285,6 +285,13 @@ const dumpListeners = () => {
         if (screenStore.get(screen.screen_name)?.pinned) {
             toggleScreen(screen.screen_name, true);
         }
+
+        // raise_in: seconds
+        if (screen.raise_in > 0) {
+            setTimeout(() => {
+                toggleScreen(screen.screen_name, true);
+            }, screen.raise_in * 1000);
+        }
     });
 
     window.ipcRenderer.on("json_validate", (event, { content }) => {


### PR DESCRIPTION
###  Feature: Implement raiseIn to Focus Screen After Delay

This PR introduces the raiseIn parameter for the toScreen() method, allowing developers to focus the target screen after a specified delay.

Usage Example:
```php
ds()->toScreen('API', raiseIn: 1); // Focuses the 'API' screen after 1 second  
```