### PR TITLE
fix: add Korean language support to settings

### DIFF
--- a/src/renderer/store/settings.ts
+++ b/src/renderer/store/settings.ts
@@ -39,7 +39,8 @@ const languageOptions = {
     zh_CN: "Chinese (CN)",
     id_ID: "Indonesian (ID)",
     al_AL: "Shqip (AL)",
-    tr_TR: "Türkçe (TR)"
+    tr_TR: "Türkçe (TR)",
+    ko_KR: "한국어 (KR)"
 };
 
 const ideHandlerOptions = {


### PR DESCRIPTION
Add missing import Korean language

<img width="314" height="294" alt="image" src="https://github.com/user-attachments/assets/01a55cd5-27ac-412c-8d96-d5eeb4300d16" />
