### PR TITLE
feat: enable copying original JSON content to clipboard

### DIFF
--- a/src/renderer/components/dumps/DumpItem.vue
+++ b/src/renderer/components/dumps/DumpItem.vue
@@ -126,6 +126,13 @@ const copyDump = () => {
             return;
         }
 
+        if (props.payload.json?.original_content) {
+            navigator.clipboard.writeText(props.payload.json?.original_content).then(() => {
+                toast.show(t("toast_copied_to_clipboard"), "success");
+            });
+            return;
+        }
+
         const value = document.getElementById(`dump-content-${props.payload.sf_dump_id}`)?.innerText;
 
         navigator.clipboard.writeText(value).then(() => {


### PR DESCRIPTION
https://github.com/laradumps/app/issues/462

This pull request updates the clipboard copy logic in the `DumpItem.vue` component to prioritize copying the original JSON content if available. This improves the user experience by ensuring that the most accurate data is copied when possible.

Clipboard copy behavior improvement:

* Updated the `copyDump` function in `DumpItem.vue` to check for and copy `original_content` from the JSON payload if present, showing a success toast notification. If not present, the function falls back to copying the rendered content as before.