### PR TITLE
feat: highlight duplicated queries in the UI and improve styling

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -115,7 +115,7 @@ function createWindow(): BrowserWindow {
 }
 
 ipcMain.on("dump", (event: Electron.IpcMainEvent, arg): void => {
-    mainWindow.webContents.send("new.dumps");
+    mainWindow.webContents.send("dumps");
     event.sender.send(arg.type, arg);
 });
 

--- a/src/renderer/components/dumps/DumpItem.vue
+++ b/src/renderer/components/dumps/DumpItem.vue
@@ -328,6 +328,13 @@ const isPercentageColors = computed(() => {
     return props.payload.type == "queries" && queriesChart.type === "percentage-colors";
 });
 
+const isHighlighted = computed(() => {
+    if (!props.payload.queries?.query.sql || !duplicatesStore.selectedSql) {
+        return false;
+    }
+    return duplicatesStore.selectedSql === props.payload.queries.query.sql;
+});
+
 onUnmounted(() => {
     window.removeEventListener("keydown", onKeydown);
     window.removeEventListener("ld-context-open", onOtherContextOpen as EventListener);
@@ -341,6 +348,7 @@ onUnmounted(() => {
             :class="{
                 'border border-base-content/5': isPercentageColors,
                 'collapse-open': open,
+                'highlight-duplicated': isHighlighted,
                 [containerClasses]: true
             }"
             class="border-base-300 collapse rounded-none"
@@ -646,5 +654,21 @@ onUnmounted(() => {
 
 .vjs-comment {
     @apply !text-xs;
+}
+
+
+@keyframes blink-red-border {
+    0%,
+    100% {
+        border-color: var(--color-error);
+    }
+    50% {
+        border-color: transparent;
+    }
+}
+
+.highlight-duplicated {
+    @apply border border-solid border-error/40 bg-error/5 rounded-md shadow-lg;
+    animation: blink-red-border 1s 3;
 }
 </style>

--- a/src/renderer/components/laravel/DumpQueries.vue
+++ b/src/renderer/components/laravel/DumpQueries.vue
@@ -33,13 +33,6 @@ const showToggleControls = ref(false);
 const resizeObserver = ref<ResizeObserver | null>(null);
 const isManualToggle = ref(false);
 
-const isHighlighted = computed(() => {
-    if (!props.payload.queries?.query.sql || !duplicatesStore.selectedSql) {
-        return false;
-    }
-    return duplicatesStore.selectedSql === props.payload.queries.query.sql;
-});
-
 const checkContainerHeight = () => {
     if (!codeContainer.value || isManualToggle.value) return;
 
@@ -121,8 +114,7 @@ const formattedSql = computed(() => {
 <template>
     <div
         v-if="payload.queries"
-        class="rounded-sm space-y-2 p-2"
-        :class="{ 'highlight-duplicated': isHighlighted }"
+        class="rounded-sm space-y-3 p-2 pt-0"
     >
         <dialog
             ref="modalRef"
@@ -166,6 +158,7 @@ const formattedSql = computed(() => {
                     title="This query has problematic nodes in the EXPLAIN plan."
                 >
                     <BoltIcon class="w-4" />
+                    <span>Explain</span>
                 </button>
 
                 <!-- Duplicated Query Icon -->
@@ -175,6 +168,7 @@ const formattedSql = computed(() => {
                     class="btn btn-soft btn-xs btn-error"
                 >
                     <ExclamationTriangleIcon class="w-4" />
+                    <span>Duplicated</span>
                 </button>
             </div>
         </div>
@@ -236,20 +230,5 @@ code.line-clamp-[14] {
 code:not(.line-clamp-[14]) {
     max-height: none;
     transition: max-height 0.3s ease;
-}
-
-@keyframes blink-red-border {
-    0%,
-    100% {
-        border-color: #ef4444; /* red-500 */
-    }
-    50% {
-        border-color: transparent;
-    }
-}
-
-.highlight-duplicated {
-    @apply border border-solid border-error rounded-md shadow-md;
-    animation: blink-red-border 1s 3;
 }
 </style>

--- a/src/renderer/components/laravel/QueriesView.vue
+++ b/src/renderer/components/laravel/QueriesView.vue
@@ -499,15 +499,15 @@ const convertMsToHumanReadable = (): string => {
             class="space-y-2"
             v-if="queriesStore.payload.length > 0 && timeStore.selected"
         >
-            <div class="flex justify-between">
+            <div class="flex justify-between items-center">
                 <button
-                    class="btn btn-soft btn-sm hover:text-primary text-sm font-normal"
+                    class="btn btn-soft bg-base-100 btn-sm text-xs font-normal p-2 pr-3 rounded-full"
                     @click="openRequestsModal()"
                 >
-                    <span class="badge rounded-full bg-primary text-primary-content text-xs font-normal p-1 px-2">
-                        {{ timeStore.getRequestCount() }}
+                    <ArrowsRightLeftIcon class="w-4 inline-block" />
+                    <span class="opacity-80">
+                        ({{ timeStore.getRequestCount() }})
                     </span>
-                    <ArrowsRightLeftIcon class="w-3.5 inline-block" />
                     {{ timeStore.getSelectedRequest().uri ? timeStore.getSelectedRequest().uri : "Tinker" }}
                 </button>
                 <span class="text-base font-sans text-primary font-normal">{{ convertMsToHumanReadable() }}</span>

--- a/src/renderer/components/navbar/NavBarSettings.vue
+++ b/src/renderer/components/navbar/NavBarSettings.vue
@@ -1,22 +1,12 @@
 <script setup>
-import { onMounted, ref } from "vue";
+import { ref } from "vue";
 import { CogIcon, HomeIcon } from "@heroicons/vue/24/outline";
-import router from "../../router";
-import { useXDebug } from "@/store/xdebug";
-
-const xDebugStore = useXDebug();
 
 const inSettingPage = ref(false);
 
 const togglePage = () => {
     inSettingPage.value = !inSettingPage.value;
 };
-
-onMounted(() => {
-    window.ipcRenderer.on("new.dumps", (event) => {
-        router.push({ name: "home" }, { xdebug: xDebugStore.current !== "" });
-    });
-});
 </script>
 
 <template>


### PR DESCRIPTION
This pull request introduces improvements to how duplicated SQL queries are highlighted in the UI, refines some button and badge styling, and removes unused code related to duplicated query highlighting in one component. The main focus is on making duplicated queries more visually distinct and enhancing user feedback, while cleaning up redundant logic.

Related issues: https://github.com/laradumps/app/issues/467, https://github.com/laradumps/app/issues/465

**UI and Highlighting Improvements**

* Added a new computed property `isHighlighted` in `DumpItem.vue` to determine if a query should be visually marked as duplicated, and applied a new animated highlight style via the `highlight-duplicated` class. [[1]](diffhunk://#diff-ef4c5b2d4f90ded2f6f0492e88b6339084bfab7e82b1f32177d24e8bb07ea5f6R331-R337) [[2]](diffhunk://#diff-ef4c5b2d4f90ded2f6f0492e88b6339084bfab7e82b1f32177d24e8bb07ea5f6R351) [[3]](diffhunk://#diff-ef4c5b2d4f90ded2f6f0492e88b6339084bfab7e82b1f32177d24e8bb07ea5f6R658-R673)
* Removed the duplicated query highlighting logic and associated CSS from `DumpQueries.vue`, centralizing the highlight feature in `DumpItem.vue`. [[1]](diffhunk://#diff-101ede15972679505405ad974cbaeda47fa95b053b44574d80b55102c94e1f77L36-L42) [[2]](diffhunk://#diff-101ede15972679505405ad974cbaeda47fa95b053b44574d80b55102c94e1f77L124-R117) [[3]](diffhunk://#diff-101ede15972679505405ad974cbaeda47fa95b053b44574d80b55102c94e1f77L240-L254)

**Button and Badge Styling**

* Updated the request selection button in `QueriesView.vue` to include an icon, adjust padding, and improve badge readability for request counts.
* Added descriptive text ("Explain" and "Duplicated") to relevant action buttons for better clarity in `DumpQueries.vue`. [[1]](diffhunk://#diff-101ede15972679505405ad974cbaeda47fa95b053b44574d80b55102c94e1f77R161) [[2]](diffhunk://#diff-101ede15972679505405ad974cbaeda47fa95b053b44574d80b55102c94e1f77R171)

**Code Cleanup**

* Removed unused imports and event handling code from `NavBarSettings.vue`, streamlining the component and removing logic that responded to the old `"new.dumps"` event.

**IPC Event Renaming**

* Changed the IPC event sent from `"new.dumps"` to `"dumps"` in `main.ts` for consistency with the rest of the codebase.