### PR TITLE
Add "Copy to Markdown"

### DIFF
--- a/src/renderer/components/laravel/LogView.vue
+++ b/src/renderer/components/laravel/LogView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, defineProps, ref, watch, nextTick, onMounted, onUnmounted } from "vue";
 import moment from "moment";
-import { FunnelIcon, PlayIcon, TrashIcon } from "@heroicons/vue/24/outline";
+import { FunnelIcon, PlayIcon, TrashIcon, ClipboardDocumentIcon } from "@heroicons/vue/24/outline";
 import { ExclamationCircleIcon, ExclamationTriangleIcon, InformationCircleIcon } from "@heroicons/vue/24/outline";
 
 import { Log, useLogStore } from "@/store/logs";
@@ -13,6 +13,7 @@ import IconPause from "@/components/Icons/IconPause.vue";
 import { usePauseLogsStore } from "@/store/pause-logs";
 import DumpQuery from "@/components/laravel/DumpQuery.vue";
 import { generateLink } from "@/utils/ideHandler";
+import { copyLogToMarkdown } from "@/utils/logToMarkdown";
 
 const logStore = useLogStore();
 const colorStore = useColorStore();
@@ -137,6 +138,16 @@ const handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape" && expandedLogId.value) {
         expandedLogId.value = null;
         event.preventDefault();
+    }
+};
+
+const copyToMarkdown = async (log: Log) => {
+    try {
+        await copyLogToMarkdown(log);
+        // You can add a toast notification here if you have one
+        console.log("Copied to clipboard");
+    } catch (error) {
+        console.error("Failed to copy:", error);
     }
 };
 
@@ -362,6 +373,18 @@ const getBorderColor = (level: string) => {
                                     v-if="expandedLogId === log.log_id"
                                     class="bg-base-100 px-4 py-2"
                                 >
+                                    <!-- Copy to Markdown Button -->
+                                    <div class="flex justify-end mb-2">
+                                        <button
+                                            @click.stop="copyToMarkdown(log)"
+                                            class="btn btn-sm btn-soft gap-2"
+                                            data-tippy-content="Copy to Markdown"
+                                        >
+                                            <ClipboardDocumentIcon class="w-4" />
+                                            Copy to Markdown
+                                        </button>
+                                    </div>
+
                                     <!-- Stack Trace -->
                                     <div v-if="log.code_snippet && log.code_snippet.length > 0">
                                         <CodeSnippet

--- a/src/renderer/components/laravel/LogView.vue
+++ b/src/renderer/components/laravel/LogView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, defineProps, ref, watch, nextTick, onMounted, onUnmounted } from "vue";
 import moment from "moment";
-import { FunnelIcon, PlayIcon, TrashIcon, ClipboardDocumentIcon } from "@heroicons/vue/24/outline";
+import { FunnelIcon, PlayIcon, TrashIcon, ClipboardDocumentIcon, CheckIcon } from "@heroicons/vue/24/outline";
 import { ExclamationCircleIcon, ExclamationTriangleIcon, InformationCircleIcon } from "@heroicons/vue/24/outline";
 
 import { Log, useLogStore } from "@/store/logs";
@@ -24,6 +24,7 @@ const forceUpdate = ref(0);
 const expandedLogId = ref<string | null>(null);
 const collapsedLogGroups = ref<Record<string, boolean>>({});
 const levelFilter = ref<string[]>([]);
+const copiedLogId = ref<string | null>(null);
 
 const props = defineProps<{
     items: Record<string, Log>;
@@ -144,8 +145,11 @@ const handleKeyDown = (event: KeyboardEvent) => {
 const copyToMarkdown = async (log: Log) => {
     try {
         await copyLogToMarkdown(log);
-        // You can add a toast notification here if you have one
-        console.log("Copied to clipboard");
+        copiedLogId.value = log.log_id;
+
+        setTimeout(() => {
+            copiedLogId.value = null;
+        }, 2000);
     } catch (error) {
         console.error("Failed to copy:", error);
     }
@@ -380,7 +384,14 @@ const getBorderColor = (level: string) => {
                                             class="btn btn-sm btn-soft gap-2"
                                             data-tippy-content="Copy to Markdown"
                                         >
-                                            <ClipboardDocumentIcon class="w-4" />
+                                            <CheckIcon
+                                                v-if="copiedLogId === log.log_id"
+                                                class="w-4 text-success"
+                                            />
+                                            <ClipboardDocumentIcon
+                                                v-else
+                                                class="w-4"
+                                            />
                                             Copy to Markdown
                                         </button>
                                     </div>

--- a/src/renderer/store/logs.ts
+++ b/src/renderer/store/logs.ts
@@ -14,6 +14,11 @@ export type Log = {
     color: string;
     queries: string[];
     requests: any[];
+    app?: {
+        php_version: string;
+        laravel_version: string;
+        environment: string;
+    };
 };
 
 type State = {
@@ -68,7 +73,8 @@ export const useLogStore = defineStore("logStore", {
                 ide_handle,
                 color: this._parseColor(log_application.level),
                 queries: log_application.queries || [],
-                requests: log_application.request || []
+                requests: log_application.request || [],
+                app: log_application.app || undefined
             };
         },
         _parseColor(level: string) {

--- a/src/renderer/types/Payload.ts
+++ b/src/renderer/types/Payload.ts
@@ -84,6 +84,11 @@ export interface LogApplicationPayload {
     value: string;
     queries: string[];
     request: any;
+    app?: {
+        php_version: string;
+        laravel_version: string;
+        environment: string;
+    };
 }
 
 export interface ScreenPayload {
@@ -102,10 +107,6 @@ export interface CodeSnippet {
     file: string;
     line: number;
     snippet: Record<string, string>;
-}
-export interface Meta {
-    auto_invoke_app: string;
-    laradumps_version: string;
 }
 
 export interface StrContainsPayload {

--- a/src/renderer/utils/logToMarkdown.ts
+++ b/src/renderer/utils/logToMarkdown.ts
@@ -1,0 +1,183 @@
+import { Log } from "@/store/logs";
+
+export function logToMarkdown(log: Log): string {
+    const lines: string[] = [];
+
+    // Title
+    lines.push(`# ${log.level.toUpperCase()} - ${log.message}`);
+    lines.push("");
+
+    // Application Information
+    if (log.app) {
+        if (log.app.php_version) {
+            lines.push(`**PHP Version:** ${log.app.php_version}`);
+        }
+        if (log.app.laravel_version) {
+            lines.push(`**Laravel Version:** ${log.app.laravel_version}`);
+        }
+        if (log.app.environment) {
+            lines.push(`**Environment:** ${log.app.environment}`);
+        }
+        lines.push("");
+    }
+
+    // Stack Trace
+    if (log.code_snippet && log.code_snippet.length > 0) {
+        lines.push("## Stack Trace");
+        lines.push("");
+
+        if (log.ide_handle && log.ide_handle.class_name !== "empty") {
+            lines.push(`**File:** \`${log.ide_handle.class_name}:${log.ide_handle.line}\``);
+            lines.push("");
+        }
+
+        // Limit to last 10 frames
+        const frames = log.code_snippet.slice(0, 10);
+        const hasMore = log.code_snippet.length > 10;
+
+        frames.forEach((frame: any, frameIndex: number) => {
+            if (frame && frame.snippet) {
+                lines.push(`### Frame ${frameIndex + 1}`);
+                lines.push("");
+                lines.push(`**File:** \`${frame.file}:${frame.line}\``);
+                lines.push(`**Route:** \`${frame.route}\``);
+                lines.push("");
+                lines.push("```php");
+
+                Object.entries(frame.snippet).forEach(([lineNumber, code]) => {
+                    if (code) {
+                        lines.push(`${lineNumber} - ${code}`);
+                    }
+                });
+
+                lines.push("```");
+                lines.push("");
+            }
+        });
+
+        if (hasMore) {
+            lines.push(`*... and ${log.code_snippet.length - 10} more frames*`);
+            lines.push("");
+        }
+    }
+
+    // Payload
+    if (log.context && log.context.length > 0 && log.context[0]) {
+        lines.push("## Payload");
+        lines.push("");
+
+        // Strip HTML tags for markdown
+        let cleanPayload = log.context[0]
+            .replace(/<[^>]*>/g, "")
+            .replace(/&quot;/g, '"')
+            .replace(/&lt;/g, "<")
+            .replace(/&gt;/g, ">")
+            .replace(/&amp;/g, "&");
+
+        // Try to parse and prettify JSON if it's valid JSON
+        try {
+            const parsed = JSON.parse(cleanPayload);
+
+            // If it has a snapshot field that's stringified JSON, parse it too
+            if (parsed.snapshot && typeof parsed.snapshot === "string") {
+                try {
+                    parsed.snapshot = JSON.parse(parsed.snapshot);
+                } catch {
+                    // Keep as string if can't parse
+                }
+            }
+
+            cleanPayload = JSON.stringify(parsed, null, 2);
+        } catch {
+            // Not JSON or invalid JSON, keep as is
+        }
+
+        lines.push("```json");
+        lines.push(cleanPayload);
+        lines.push("```");
+        lines.push("");
+    }
+
+    // Request
+    if (log.requests) {
+        lines.push("## Request");
+        lines.push("");
+
+        // Headers
+        lines.push("### Headers");
+        lines.push("");
+
+        if (log.requests.headers && Object.keys(log.requests.headers).length > 0) {
+            Object.entries(log.requests.headers).forEach(([key, value]) => {
+                lines.push(`- **${key}:** \`${value}\``);
+            });
+        } else {
+            lines.push("*No header data available.*");
+        }
+        lines.push("");
+
+        // Body
+        if (log.requests.body) {
+            lines.push("### Body");
+            lines.push("");
+
+            // Try to parse and prettify JSON body
+            let formattedBody = log.requests.body;
+            try {
+                const parsed = JSON.parse(formattedBody);
+                formattedBody = JSON.stringify(parsed, null, 2);
+            } catch {
+                // Keep as is if not valid JSON
+            }
+
+            lines.push("```json");
+            lines.push(formattedBody);
+            lines.push("```");
+            lines.push("");
+        }
+    }
+
+    // Route Context
+    lines.push("## Route Context");
+    lines.push("");
+
+    if (log.requests?.routeContext && Object.keys(log.requests.routeContext).length > 0) {
+        Object.entries(log.requests.routeContext).forEach(([key, value]) => {
+            lines.push(`- **${key}:** \`${value}\``);
+        });
+    } else {
+        lines.push("*No routing data available.*");
+    }
+    lines.push("");
+
+    // Database Queries
+    lines.push("## Database Queries");
+    lines.push("");
+
+    if (log.queries && log.queries.length > 0) {
+        log.queries.forEach((query, index) => {
+            const connectionName = query.connection_name || "default";
+            const time = query.time || 0;
+
+            lines.push(`### Query ${index + 1}`);
+            lines.push("");
+            lines.push(`**Connection:** ${connectionName}`);
+            lines.push(`**Time:** ${time} ms`);
+            lines.push("");
+            lines.push("```sql");
+            lines.push(query.sql);
+            lines.push("```");
+            lines.push("");
+        });
+    } else {
+        lines.push("*No database queries detected.*");
+        lines.push("");
+    }
+
+    return lines.join("\n");
+}
+
+export async function copyLogToMarkdown(log: Log): Promise<void> {
+    const markdown = logToMarkdown(log);
+    await navigator.clipboard.writeText(markdown);
+}


### PR DESCRIPTION
This pull request adds a "Copy to Markdown" feature to the Laravel Log Viewer, allowing users to export log entries as well-formatted Markdown for easier sharing or documentation. It introduces a utility to convert log data—including stack traces, payloads, request info, and queries—into Markdown, and updates the UI to provide a button for this action. Additionally, the log data structures are extended to support richer application metadata.

<img width="854" height="486" alt="image" src="https://github.com/user-attachments/assets/9f649f22-39c4-4bb1-9cec-523115e34f8b" />

https://github.com/laravel/framework/pull/56657

- https://github.com/laradumps/laradumps/pull/249

Resolves: https://github.com/laradumps/app/issues/484