### PR TITLE
Tmp disables Snapcraft

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,17 +28,17 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-            - name: Install Snapcraft
-              if: matrix.os == 'ubuntu-latest'
-              run: |
-                  sudo snap install snapcraft --classic
+#            - name: Install Snapcraft
+#              if: matrix.os == 'ubuntu-latest'
+#              run: |
+#                  sudo snap install snapcraft --classic
 
-            - name: 🐧 Release Linux
-              if: matrix.os == 'ubuntu-latest'
-              run: npm run publish-linux
-              env:
-                  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-                  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+#            - name: 🐧 Release Linux
+#              if: matrix.os == 'ubuntu-latest'
+#              run: npm run publish-linux
+#              env:
+#                  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+#                  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
             - name: 💻 Release Windows
               if: matrix.os == 'windows-latest'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "laradumps",
-    "version": "4.10.3",
+    "version": "4.10.4",
     "private": false,
     "description": "LaraDumps is a friendly app designed to boost your PHP coding and debugging experience. https://github.com/laradumps/app",
     "author": "Luan Freitas <luanfreitas10@protonmail.com>",
@@ -137,8 +137,7 @@
             "description": "LaraDumps a friendly app designed to boost your PHP coding and debugging experience. https://github.com/laradumps/app",
             "icon": "./build/icon.icns",
             "target": [
-                "AppImage",
-                "snap"
+                "AppImage"
             ],
             "desktop": {
                 "entry": "build/linux/laradumps.desktop"


### PR DESCRIPTION
This pull request primarily disables Snapcraft-related functionality for Linux releases, both in the build workflow and in the application packaging configuration. Additionally, it increments the application version number.

Release process changes:

* Commented out the Snapcraft installation and Linux release steps in the GitHub Actions workflow file `.github/workflows/build.yml`, effectively disabling Snap-based publishing for Linux.
* Removed the `snap` target from the Linux build configuration in `package.json`, so builds will now only produce AppImage artifacts for Linux.

---

CI Error:
Uploading... (--->)
Uploading... (<---)
Status: processing
Status: processing
Status: processing
Status: error while processing
Issues while processing snap:
- Waiting for previous upload(s) to complete their review process. If you want to prioritize this last one, go to the other upload(s) page in https://dashboard.snapcraft.io/ and click on the 'Reject and remove from review queue' button.
Full execution log: '/home/runner/.local/state/snapcraft/log/snapcraft-20260129-124423.798142.log'
  ⨯ exit status 1
github.com/develar/app-builder/pkg/util.ExecuteAndPipeStdOutAndStdErr
	/Users/runner/work/app-builder/app-builder/pkg/util/exec.go:23
github.com/develar/app-builder/pkg/package-format/snap.publishToStore
	/Users/runner/work/app-builder/app-builder/pkg/package-format/snap/snapStore.go:35
github.com/develar/app-builder/pkg/package-format/snap.ConfigurePublishCommand.func1
	/Users/runner/work/app-builder/app-builder/pkg/package-format/snap/snapStore.go:18
github.com/alecthomas/kingpin.(*actionMixin).applyActions
	/Users/runner/go/pkg/mod/github.com/alecthomas/kingpin@v2.2.6+incompatible/actions.go:28
github.com/alecthomas/kingpin.(*Application).applyActions
	/Users/runner/go/pkg/mod/github.com/alecthomas/kingpin@v2.2.6+incompatible/app.go:557
github.com/alecthomas/kingpin.(*Application).execute
	/Users/runner/go/pkg/mod/github.com/alecthomas/kingpin@v2.2.6+incompatible/app.go:390
github.com/alecthomas/kingpin.(*Application).Parse
	/Users/runner/go/pkg/mod/github.com/alecthomas/kingpin@v2.2.6+incompatible/app.go:222
main.main
	/Users/runner/work/app-builder/app-builder/main.go:90
runtime.main
	/Users/runner/hostedtoolcache/go/1.21.13/arm64/src/runtime/proc.go:267
runtime.goexit
	/Users/runner/hostedtoolcache/go/1.21.13/arm64/src/runtime/asm_amd64.s:1650  
  ⨯ /home/runner/work/app/app/node_modules/app-builder-bin/linux/x64/app-builder process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
Exit code:
1  failedTask=build stackTrace=Error: /home/runner/work/app/app/node_modules/app-builder-bin/linux/x64/app-builder process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
Exit code:
1
    at ChildProcess.<anonymous> (/home/runner/work/app/app/node_modules/builder-util/src/util.ts:272:14)
    at Object.onceWrapper (node:events:634:26)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1101:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:304:5)

---

Other changes:

* Bumped the application version from `4.10.3` to `4.10.4` in `package.json`.