### PR TITLE
fix: use process.execPath for spawning MCP server to ensure correct...

### DIFF
--- a/src/main/mcp-manager.ts
+++ b/src/main/mcp-manager.ts
@@ -39,7 +39,9 @@ export const startMcpServer = () => {
 
     sendLog(`Starting MCP server on port ${port}...`);
 
-    mcpProcess = spawn('node', [scriptPath, '--port', port.toString()], {
+    const nodeExecutable = process.execPath;
+
+    mcpProcess = spawn(nodeExecutable, [scriptPath, '--port', port.toString()], {
         stdio: 'pipe',
         env: process.env
     });


### PR DESCRIPTION
https://github.com/laradumps/app/issues/508

This pull request makes a small but important change to how the MCP server process is started. Instead of hardcoding the use of the `node` command, it now uses the current Node.js executable path, improving compatibility across different environments.

- Process management improvement:
  * Updated `startMcpServer` in `src/main/mcp-manager.ts` to use `process.execPath` as the Node.js executable, ensuring the spawned process uses the same Node.js version as the parent process.