### PR TITLE
fix: enhance MCP server startup process and logging mechanism (macos)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "laradumps",
-    "version": "4.11.1",
+    "version": "4.11.2",
     "private": false,
     "description": "LaraDumps is a friendly app designed to boost your PHP coding and debugging experience. https://github.com/laradumps/app",
     "author": "Luan Freitas <luanfreitas10@protonmail.com>",
@@ -94,6 +94,9 @@
     "build": {
         "appId": "com.laradumps.app",
         "productName": "LaraDumps",
+        "asarUnpack": [
+            "dist/mcp-server.js"
+        ],
         "files": [
             "**/*",
             "!node_modules${/*}"

--- a/src/main/mcp-manager.ts
+++ b/src/main/mcp-manager.ts
@@ -1,9 +1,11 @@
 import { spawn, ChildProcess } from 'child_process';
+import fs from 'fs';
 import { app, ipcMain, BrowserWindow } from 'electron';
 import path from 'path';
 import * as settings from './settings';
 
 let mcpProcess: ChildProcess | null = null;
+let consolePipeBroken = false;
 
 const getMcpServerPath = () => {
     const appPath = app.getAppPath();
@@ -13,7 +15,54 @@ const getMcpServerPath = () => {
         return path.resolve(appPath, 'dist', 'mcp-server.js');
     }
 
-    return path.resolve(appPath.replace('app.asar', 'app.asar.unpacked'), 'dist', 'mcp-server.js');
+    const unpackedPath = path.resolve(appPath.replace('app.asar', 'app.asar.unpacked'), 'dist', 'mcp-server.js');
+    if (fs.existsSync(unpackedPath)) {
+        return unpackedPath;
+    }
+
+    return path.resolve(appPath, 'dist', 'mcp-server.js');
+};
+
+const sendLog = (message: string, type: 'info' | 'error' = 'info') => {
+    const timestamp = new Date().toISOString().split('T')[1].split('.')[0];
+    const logLine = `[${timestamp}] [${type}] ${message}`;
+
+    if (!consolePipeBroken) {
+        try {
+            console.log(logLine);
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException)?.code === 'EPIPE') {
+                consolePipeBroken = true;
+            } else {
+                throw error;
+            }
+        }
+    }
+
+    BrowserWindow.getAllWindows().forEach((win) => {
+        win.webContents.send('mcp:log', logLine);
+    });
+};
+
+const resolveNodeCommand = () => {
+    const customNode = process.env.MCP_NODE_PATH;
+    if (customNode && fs.existsSync(customNode)) {
+        return { command: customNode, env: { ...process.env } };
+    }
+
+    return {
+        command: process.execPath,
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
+    };
+};
+
+const ensureServerBundle = (scriptPath: string) => {
+    if (fs.existsSync(scriptPath)) {
+        return true;
+    }
+
+    sendLog(`MCP server bundle not found at ${scriptPath}. Run "npm run build" to regenerate it.`, 'error');
+    return false;
 };
 
 export const startMcpServer = () => {
@@ -22,29 +71,30 @@ export const startMcpServer = () => {
     const currentSettings = settings.getSettings();
 
     if (!currentSettings.mcp_enabled) {
+        sendLog('MCP server is disabled in the current settings.');
         return;
     }
 
     const scriptPath = getMcpServerPath();
     const port = currentSettings.mcp_port || 3002;
 
-    const sendLog = (message: string, type: 'info' | 'error' = 'info') => {
-        const timestamp = new Date().toISOString().split('T')[1].split('.')[0];
-        const logLine = `[${timestamp}] [${type}] ${message}`;
-        console.log(logLine);
-        BrowserWindow.getAllWindows().forEach((win) => {
-            win.webContents.send('mcp:log', logLine);
-        });
-    };
+    if (!ensureServerBundle(scriptPath)) {
+        return;
+    }
+
+    const { command, env } = resolveNodeCommand();
 
     sendLog(`Starting MCP server on port ${port}...`);
 
-    const nodeExecutable = process.execPath;
-
-    mcpProcess = spawn(nodeExecutable, [scriptPath, '--port', port.toString()], {
-        stdio: 'pipe',
-        env: process.env
-    });
+    try {
+        mcpProcess = spawn(command, [scriptPath, '--port', port.toString()], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env
+        });
+    } catch (error) {
+        sendLog(`Failed to spawn MCP server process: ${(error as Error).message}`, 'error');
+        return;
+    }
 
     if (mcpProcess.stdout) {
         mcpProcess.stdout.on('data', (data) => {


### PR DESCRIPTION
This pull request introduces several improvements to the handling and launching of the MCP server, focusing on robustness, configurability, and packaging. The main changes include enhanced logging, better server bundle handling, support for custom Node.js executables, and adjustments to the Electron packaging configuration.

**MCP Server Process Improvements:**

* Refactored the MCP server startup logic in `mcp-manager.ts` to include robust logging with timestamps, error handling for broken console pipes, and broadcasting logs to all open Electron windows.
* Added a check to ensure the MCP server bundle exists before attempting to start it, with clear error messages if missing.
* Introduced support for a custom Node.js executable via the `MCP_NODE_PATH` environment variable, improving flexibility for different environments.
* Improved error handling when spawning the MCP server process, logging failures instead of crashing.

**Electron Packaging Adjustments:**

* Updated `package.json` to unpack `dist/mcp-server.js` when packaging with Electron's asar, ensuring the server script is accessible at runtime.
* Bumped the package version from `4.11.1` to `4.11.2` to reflect these enhancements.

https://github.com/laradumps/app/issues/508