### PR TITLE
Add `get_problematic_queries` tool

### DIFF
--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -43,6 +43,8 @@ export async function createMcpServer(
     logger('Prompts registered');
 
     let httpServer: http.Server | null = null;
+    let currentTransport: StreamableHTTPServerTransport | null = null;
+    let isTransportValid = false;
 
     if (port > 0) {
         logger(`HTTP mode - Starting Express app...`);
@@ -53,17 +55,6 @@ export async function createMcpServer(
         app.use(express.json({ limit: '10mb' }));
 
         logger('Express app created, CORS and JSON middleware enabled');
-
-        logger('Configuring StreamableHTTPServerTransport...');
-        // @ts-ignore
-        const transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: () => crypto.randomUUID()
-        });
-        logger('Transport configured with sessionIdGenerator');
-
-        logger('Connecting MCP Server to transport...');
-        await server.connect(transport);
-        logger('MCP Server connected to transport');
 
         logger('Registering endpoints...');
 
@@ -78,10 +69,24 @@ export async function createMcpServer(
             try {
                 logger('Handling GET /sse request');
                 logger(`  Headers: ${JSON.stringify(req.headers)}`);
-                await transport.handleRequest(req, res);
+
+                if (!currentTransport || !isTransportValid) {
+                    await server.close();
+                    // @ts-ignore
+                    currentTransport = new StreamableHTTPServerTransport({
+                        sessionIdGenerator: () => crypto.randomUUID()
+                    });
+
+                    await server.connect(currentTransport);
+                    isTransportValid = true;
+                    logger('New transport created for SSE');
+                }
+
+                await currentTransport.handleRequest(req, res);
                 logger('GET /sse request handled');
             } catch (err) {
                 logger(`CRITICAL Error in GET /sse: ${err}`, 'error');
+                isTransportValid = false;
                 if (err instanceof Error) {
                     logger(`Stack: ${err.stack}`, 'error');
                 }
@@ -108,13 +113,23 @@ export async function createMcpServer(
             try {
                 logger(`Handling POST ${req.path} request`);
                 logger(`  Headers: ${JSON.stringify(req.headers)}`);
-                // The SDK's handleRequest for Node.js expects to be able to read the body
-                // from the request object if parsedBody is not provided.
-                // Since we have express.json(), req.body is already populated.
-                await transport.handleRequest(req, res, req.body);
+
+                if (!currentTransport || !isTransportValid) {
+                    await server.close();
+                    // @ts-ignore
+                    currentTransport = new StreamableHTTPServerTransport({
+                        sessionIdGenerator: () => crypto.randomUUID()
+                    });
+                    await server.connect(currentTransport);
+                    isTransportValid = true;
+                    logger('New transport created for POST');
+                }
+
+                await currentTransport.handleRequest(req, res, req.body);
                 logger(`POST ${req.path} request handled`);
             } catch (err) {
                 logger(`CRITICAL Error in POST ${req.path}: ${err}`, 'error');
+                isTransportValid = false;
                 if (err instanceof Error) {
                     logger(`Stack: ${err.stack}`, 'error');
                 }
@@ -154,7 +169,13 @@ export async function createMcpServer(
     return {
         server,
         httpServer,
-        stop: () => {
+        stop: async () => {
+            if (currentTransport) {
+                logger('Closing transport...');
+                await server.close();
+                currentTransport = null;
+                isTransportValid = false;
+            }
             if (httpServer) {
                 logger('Closing HTTP server...');
                 httpServer.close();

--- a/src/mcp-server/tools/queries.ts
+++ b/src/mcp-server/tools/queries.ts
@@ -26,4 +26,25 @@ export function registerQueryTools(server: McpServer) {
             };
         }
     );
+
+    server.registerTool(
+        'get_problematic_queries',
+        {
+            description: 'Get problematic SQL queries (duplicates or with EXPLAIN nodes)',
+            inputSchema: {
+                limit: z.number().optional().describe('Limit the number of problematic queries returned')
+            }
+        },
+        async ({ limit }) => {
+            const endpoint = limit ? `problematic-queries?limit=${limit}` : 'problematic-queries';
+            const data = await fetchData(endpoint);
+            if (data.error) return { content: [{ type: 'text', text: `Error: ${data.error}` }] };
+
+            const problematicQueries = Array.isArray(data) ? data : Object.values(data);
+
+            return {
+                content: [{ type: 'text', text: JSON.stringify(problematicQueries, null, 2) }]
+            };
+        }
+    );
 }

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -146,6 +146,95 @@ app.get('/api/mcp/queries', (req, res) => {
     }
 });
 
+app.get('/api/mcp/queries-full', (req, res) => {
+    try {
+        const queries = applyLimit(window.LaraDumps?.queriesStore?.payload);
+        res.send(queries);
+    } catch (e) {
+        console.error('[MCP Queries Full Error]', e);
+        res.status(503).send({ error: 'Store not initialized or error retrieving queries' });
+    }
+});
+
+app.get('/api/mcp/problematic-queries', (req, res) => {
+    try {
+        const queries = window.LaraDumps?.queriesStore?.payload || [];
+
+        const requestSqlCounts = new Map();
+        for (const item of queries) {
+            if (item.queries?.query?.sql) {
+                const requestId = item.request_id;
+                const sql = item.queries.query.sql;
+
+                if (!requestSqlCounts.has(requestId)) {
+                    requestSqlCounts.set(requestId, new Map());
+                }
+                const sqlMap = requestSqlCounts.get(requestId);
+                sqlMap.set(sql, (sqlMap.get(sql) || 0) + 1);
+            }
+        }
+
+        const duplicatesInfo = [];
+        for (const [requestId, sqlMap] of requestSqlCounts.entries()) {
+            for (const [sql, count] of sqlMap.entries()) {
+                if (count > 1) {
+                    duplicatesInfo.push({
+                        request_id: requestId,
+                        sql: sql,
+                        occurrences: count
+                    });
+                }
+            }
+        }
+
+        const duplicatedSqls = new Set(duplicatesInfo.map((d) => d.sql));
+
+        const problematicQueries = queries.filter((query) => {
+            const hasExplainNodes = query.queries?.explain_nodes && query.queries.explain_nodes.length > 0;
+            const isDuplicated = duplicatedSqls.has(query.queries?.query?.sql);
+            return hasExplainNodes || isDuplicated;
+        });
+
+        const enrichedQueries = problematicQueries.map((query) => {
+            const sql = query.queries?.query?.sql || '';
+            const hasExplainNodes = query.queries?.explain_nodes && query.queries.explain_nodes.length > 0;
+            const isDuplicated = duplicatedSqls.has(sql);
+            const duplicateInfo = duplicatesInfo.find((d) => d.sql === sql);
+
+            return {
+                id: query.id,
+                request_id: query.request_id,
+                date_time: query.date_time,
+                sql: sql,
+                time: query.queries?.query?.time || 0,
+                database: query.queries?.database || '',
+                bindings: query.queries?.query?.bindings || [],
+                uri: query.queries?.uri || '',
+                method: query.queries?.method || '',
+                explain_nodes: query.queries?.explain_nodes || [],
+                ide_handle: query.ide_handle
+                    ? {
+                          real_path: query.ide_handle.real_path,
+                          class_name: query.ide_handle.class_name,
+                          line: query.ide_handle.line
+                      }
+                    : null,
+                _problematic: {
+                    has_explain_nodes: hasExplainNodes,
+                    is_duplicated: isDuplicated,
+                    occurrences: duplicateInfo?.occurrences || 1
+                }
+            };
+        });
+
+        const limit = parseInt(req.query.limit) || enrichedQueries.length;
+        res.send(enrichedQueries.slice(-limit));
+    } catch (e) {
+        console.error('[MCP Problematic Queries Error]', e);
+        res.status(503).send({ error: 'Store not initialized or error retrieving queries' });
+    }
+});
+
 app.get('/api/mcp/jobs', (req, res) => {
     try {
         const jobs = applyLimit(window.LaraDumps?.jobStore?.jobs);


### PR DESCRIPTION
This pull request introduces improvements to the MCP server's transport management for HTTP requests and adds new API endpoints and tooling for analyzing problematic SQL queries. The main focus is on making the server more robust by handling transport errors gracefully, and on providing richer diagnostics for SQL queries, including detection of duplicates and queries with EXPLAIN nodes.

**Transport management improvements:**

* Refactored the MCP server's HTTP transport logic to instantiate and connect a new `StreamableHTTPServerTransport` only when needed (i.e., when the previous transport is invalid or missing), improving error recovery and stability for both SSE and POST endpoints. The transport is now reset on error, and the server is properly closed and reconnected as required. [[1]](diffhunk://#diff-dbaf282b819ee9bf278284d2e2ae53c4e74ae26e9ba755c297651fdd1a6e3221R46-R47) [[2]](diffhunk://#diff-dbaf282b819ee9bf278284d2e2ae53c4e74ae26e9ba755c297651fdd1a6e3221L57-L67) [[3]](diffhunk://#diff-dbaf282b819ee9bf278284d2e2ae53c4e74ae26e9ba755c297651fdd1a6e3221L81-R89) [[4]](diffhunk://#diff-dbaf282b819ee9bf278284d2e2ae53c4e74ae26e9ba755c297651fdd1a6e3221L111-R132)
* Updated the server's `stop` method to asynchronously close the transport and reset its state, ensuring clean shutdowns.

**SQL query diagnostics and API enhancements:**

* Added a new Express endpoint `/api/mcp/problematic-queries` that returns SQL queries considered problematic (either duplicates or those with EXPLAIN nodes), including detailed metadata and support for limiting the number of returned entries.
* Added a new Express endpoint `/api/mcp/queries-full` for retrieving the full set of stored queries with optional limiting.
* Registered a new tool `get_problematic_queries` in the MCP server, allowing clients to programmatically fetch problematic SQL queries via the new endpoint.