### PR TITLE
fix: Environment dropdown positioning logic

### DIFF
--- a/src/renderer/components/screen/EnvironmentDropdown.vue
+++ b/src/renderer/components/screen/EnvironmentDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, computed, nextTick, watch } from 'vue';
+import { onMounted, onUnmounted, ref, nextTick, watch } from 'vue';
 import type { Environment } from '../../../main/storage';
 
 const props = defineProps<{
@@ -20,23 +20,38 @@ const selectEnvironment = (environment: Environment) => {
 
 const formattedName = (name: string): string => name?.replace(/[-_.]/g, ' ') || '';
 
+const dropdownRef = ref<HTMLElement | null>(null);
+
 const calculatePosition = () => {
+    dropdownStyle.value = {
+        top: '-9999px',
+        left: '-9999px',
+        zIndex: 9999
+    };
+
     nextTick(() => {
         const addButton = document.querySelector('[data-add-env-button]') as HTMLElement;
-        if (addButton) {
+        const dropdown = dropdownRef.value;
+
+        if (addButton && dropdown) {
             const rect = addButton.getBoundingClientRect();
-            const dropdownHeight = props.environments.length * 40 + 16;
+            const dropdownWidth = dropdown.offsetWidth || 200;
 
-            let top = rect.bottom + 4;
-            const right = window.innerWidth - rect.right;
+            const top = rect.bottom + 4;
 
-            if (top + dropdownHeight > window.innerHeight - 8) {
-                top = rect.top - dropdownHeight - 4;
+            let left = rect.left + rect.width / 2 - dropdownWidth / 2;
+
+            if (left + dropdownWidth > window.innerWidth - 8) {
+                left = window.innerWidth - dropdownWidth - 8;
+            }
+
+            if (left < 8) {
+                left = 8;
             }
 
             dropdownStyle.value = {
                 top: `${top}px`,
-                right: `${right}px`,
+                left: `${left}px`,
                 zIndex: 9999
             };
         }
@@ -78,7 +93,8 @@ onUnmounted(() => {
 <template>
     <ul
         v-if="visible"
-        class="environment-dropdown menu p-2 shadow-[0_10px_40px_rgba(0,0,0,0.5)] bg-base-200/95 backdrop-blur-xl rounded-xl border border-white/5 w-max min-w-[140px] fixed mt-1"
+        ref="dropdownRef"
+        class="environment-dropdown menu flex-col flex-nowrap p-2 shadow-[0_10px_40px_rgba(0,0,0,0.5)] bg-base-200/95 backdrop-blur-xl rounded-xl border border-white/5 w-max min-w-[140px] max-h-[340px] overflow-y-auto fixed mt-1"
         :style="{ ...dropdownStyle, zIndex: 99999 }"
     >
         <li


### PR DESCRIPTION
This pull request updates the positioning logic and styling for the environment dropdown menu in `EnvironmentDropdown.vue` to improve its usability and appearance. The main changes focus on more precise dropdown placement, enhanced styling, and improved element references.

**Dropdown positioning and element references:**
* Added a `dropdownRef` to reference the dropdown element directly, allowing for accurate calculation of its width and position. [[1]](diffhunk://#diff-6dce024a8849cc1d07413ce5a679250d29d8fe4226bac6de8c68dc86d4f12e50R23-R54) [[2]](diffhunk://#diff-6dce024a8849cc1d07413ce5a679250d29d8fe4226bac6de8c68dc86d4f12e50L81-R97)
* Updated the `calculatePosition` function to center the dropdown below the add button, prevent overflow off the screen, and use the dropdown's actual width for calculations.

**Styling and usability improvements:**
* Enhanced the dropdown menu with a maximum height, vertical scrolling, and improved flexbox layout for better usability with many environments.

**Code cleanup:**
* Removed the unused `computed` import from Vue, streamlining the imports.