### PR TITLE
ci: implement automated versioning, tagging, and multi-repo sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,56 @@ name: Release
 
 on:
     workflow_dispatch:
+        inputs:
+            version:
+                description: 'Version to release (e.g. 4.14.5)'
+                required: true
+
+permissions:
+    contents: write
 
 jobs:
-    windows:
-        runs-on: windows-latest
+    prepare:
+        runs-on: ubuntu-latest
+        outputs:
+            version: ${{ steps.set-version.outputs.version }}
         steps:
             - name: Check out Git repository
               uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.GH_TOKEN }}
+
+            - name: Install Node.js and npm
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '22.x'
+
+            - name: Bump version, commit and tag
+              id: set-version
+              run: |
+                  VERSION="${{ github.event.inputs.version }}"
+                  echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+                  git config user.name "laradumps-bot"
+                  git config user.email "laradumps@proton.me"
+
+                  jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+                  git add package.json
+                  git commit -m "v${VERSION}"
+                  git tag "v${VERSION}"
+                  git push
+                  git push --tags
+
+    windows:
+        needs: prepare
+        runs-on: windows-latest
+        env:
+            VERSION: ${{ needs.prepare.outputs.version }}
+        steps:
+            - name: Check out Git repository
+              uses: actions/checkout@v4
+              with:
+                  ref: v${{ needs.prepare.outputs.version }}
 
             - name: Install Node.js and npm
               uses: actions/setup-node@v4
@@ -29,10 +72,15 @@ jobs:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     mac:
+        needs: prepare
         runs-on: macos-latest
+        env:
+            VERSION: ${{ needs.prepare.outputs.version }}
         steps:
             - name: Check out Git repository
               uses: actions/checkout@v4
+              with:
+                  ref: v${{ needs.prepare.outputs.version }}
 
             - name: Install Node.js and npm
               uses: actions/setup-node@v4
@@ -47,16 +95,21 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-            - name:  Release Mac
+            - name: Release Mac
               run: npm run publish-mac
               env:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     linux:
+        needs: prepare
         runs-on: ubuntu-latest
+        env:
+            VERSION: ${{ needs.prepare.outputs.version }}
         steps:
             - name: Check out Git repository
               uses: actions/checkout@v4
+              with:
+                  ref: v${{ needs.prepare.outputs.version }}
 
             - name: Install Node.js and npm
               uses: actions/setup-node@v4
@@ -74,10 +127,3 @@ jobs:
               run: npm run publish-linux
               env:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-            - name: 📦 Publish Snap (non-blocking)
-              continue-on-error: true
-              run: npm run publish-snap
-              env:
-                  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-                  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,3 +127,10 @@ jobs:
               run: npm run publish-linux
               env:
                   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+            - name: 📦 Publish Snap
+              continue-on-error: true
+              run: npm run publish-snap
+              env:
+                  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+                  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,39 @@
+name: Post Release
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    post-release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Extract version from tag
+              run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
+            - name: Update Homebrew tap
+              run: |
+                  git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/laradumps/homebrew-app_2.git homebrew-app
+                  cd homebrew-app
+                  git config user.name "laradumps-bot"
+                  git config user.email "laradumps@proton.me"
+                  sh update_cask.sh "${VERSION}" "${{ secrets.GH_TOKEN }}"
+
+            - name: Update docs
+              run: |
+                  git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/laradumps/laradumps-docs.git laradumps-docs
+                  cd laradumps-docs
+
+                  FILE="docs/get-started/installation.md"
+                  OLD_VERSION=$(grep -oE 'releases/download/v[0-9]+\.[0-9]+\.[0-9]+' "$FILE" | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+
+                  sed -i "s/v${OLD_VERSION}\/LaraDumps-${OLD_VERSION}-universal\.dmg/v${VERSION}\/LaraDumps-${VERSION}-universal.dmg/g" "$FILE"
+                  sed -i "s/v${OLD_VERSION}\/LaraDumps-${OLD_VERSION}\.AppImage/v${VERSION}\/LaraDumps-${VERSION}.AppImage/g" "$FILE"
+                  sed -i "s/LaraDumps-${OLD_VERSION}\.AppImage/LaraDumps-${VERSION}.AppImage/g" "$FILE"
+                  sed -i "s/v${OLD_VERSION}\/LaraDumps-Setup-${OLD_VERSION}\.exe/v${VERSION}\/LaraDumps-Setup-${VERSION}.exe/g" "$FILE"
+
+                  git config user.name "laradumps-bot"
+                  git config user.email "laradumps@proton.me"
+                  git add "$FILE"
+                  git commit -m "v${VERSION}"
+                  git push

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,7 +13,7 @@ jobs:
 
             - name: Update Homebrew tap
               run: |
-                  git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/laradumps/homebrew-app_2.git homebrew-app
+                  git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/laradumps/homebrew-app.git homebrew-app
                   cd homebrew-app
                   git config user.name "laradumps-bot"
                   git config user.email "laradumps@proton.me"

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
         "snap": {
             "base": "core22",
             "confinement": "strict",
+            "grade": "stable",
             "summary": "LaraDumps - PHP debugging app",
             "plugs": [
                 "cups-control"


### PR DESCRIPTION
This pull request introduces an improved release workflow for the project by automating version bumps, tagging, and post-release updates to related repositories and documentation. The main changes include the addition of a `prepare` job to the build pipeline, a new `post-release` workflow, and enhancements to the Snap package configuration.

**Release workflow improvements:**

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R5-R54): Added a `prepare` job that handles version bumping, committing, tagging, and pushing changes. The `windows`, `mac`, and `linux` jobs now depend on this job and check out the correct release tag, ensuring consistent builds for all platforms. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R5-R54) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R75-R83) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L50-R112)
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L78-R131): The Snap publish step is now clearly labeled as non-blocking and continues on error, but the emoji in the step name was removed for consistency.

**Post-release automation:**

* [`.github/workflows/post-release.yml`](diffhunk://#diff-dfb63fa587b638fcf581007b525fdfb26835766b2a2be8840d19c6422f7d0ae6R1-R39): Introduced a new workflow triggered after a release is published. This workflow updates the Homebrew tap and documentation to reflect the new version automatically.

**Snap package configuration:**

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R152): Updated Snap configuration to set the `grade` to `stable`, improving release quality for Snap users.