### PR TITLE
fix: prevent right-click delete from duplicating payloads in DumpItem

### DIFF
--- a/src/renderer/components/dumps/DumpItem.vue
+++ b/src/renderer/components/dumps/DumpItem.vue
@@ -43,10 +43,6 @@ const duplicatesStore = useQueryDuplicated();
 const toast = useToastStore();
 const { t } = useI18n({ useScope: 'global' });
 
-const emit = defineEmits<{
-    (e: 'deleteDump', id: string): void;
-}>();
-
 const open = ref(true);
 const openOptions = ref(false);
 const menuX = ref(0);
@@ -695,7 +691,7 @@ onUnmounted(() => {
                                     <button
                                         class="hover:bg-base-300 rounded flex justify-between items-center"
                                         @click.stop="
-                                            deleteDump(payload.id);
+                                            payloadStore.removePayload(payload.id);
                                             openOptions = false;
                                         "
                                     >

--- a/src/renderer/views/HomeView.vue
+++ b/src/renderer/views/HomeView.vue
@@ -929,10 +929,6 @@ const hasColorsInPayload = computed((): boolean => {
     return payloadStore.payload.some((payload: Payload) => payload.color && payload.color !== 'gray');
 });
 
-const deleteDump = (id: string): void => {
-    payloadStore.removePayload(id);
-};
-
 const handleDragScreen = ({ screen, _ }) => {
     draggedScreenName.value = screen;
     isDraggingScreen.value = true;
@@ -1123,7 +1119,6 @@ const handleDragEnd = () => {
                                                             :payload="payload"
                                                             :show-time="!settingsStore.settings.grouped_by_time"
                                                             :is-first="index === 0"
-                                                            @delete-dump="deleteDump"
                                                         />
                                                     </div>
                                                 </div>
@@ -1272,7 +1267,6 @@ const handleDragEnd = () => {
                                                         :payload="payload"
                                                         :show-time="!settingsStore.settings.grouped_by_time"
                                                         :is-first="index === 0"
-                                                        @delete-dump="deleteDump"
                                                     />
                                                 </div>
                                             </div>
@@ -1405,7 +1399,6 @@ const handleDragEnd = () => {
                                                     :payload="payload"
                                                     :show-time="!settingsStore.settings.grouped_by_time"
                                                     :is-first="index === 0"
-                                                    @delete-dump="deleteDump"
                                                 />
                                             </div>
                                         </div>


### PR DESCRIPTION
This pull request refactors how dump deletion is handled in the application, simplifying the communication between the `HomeView` and `DumpItem` components. The main change is moving the dump deletion logic directly into the `DumpItem` component, removing the need to emit a `deleteDump` event and related handler in `HomeView`.

**Component communication and event handling:**

* Removed the `deleteDump` event emission and its handler from both `DumpItem.vue` and `HomeView.vue`, so that `DumpItem` now handles dump deletion internally rather than delegating it to the parent (`HomeView`). [[1]](diffhunk://#diff-ef4c5b2d4f90ded2f6f0492e88b6339084bfab7e82b1f32177d24e8bb07ea5f6L46-L49) [[2]](diffhunk://#diff-60d70f150d073bbd32e13a4f4d1e9fdebcb6242b3ed2741fae511de5462c6ef3L932-L935) [[3]](diffhunk://#diff-60d70f150d073bbd32e13a4f4d1e9fdebcb6242b3ed2741fae511de5462c6ef3L1126) [[4]](diffhunk://#diff-60d70f150d073bbd32e13a4f4d1e9fdebcb6242b3ed2741fae511de5462c6ef3L1275) [[5]](diffhunk://#diff-60d70f150d073bbd32e13a4f4d1e9fdebcb6242b3ed2741fae511de5462c6ef3L1408)

**Component logic simplification:**

* Updated the delete button in `DumpItem.vue` to call `payloadStore.removePayload(payload.id)` directly, further reducing coupling between components.

These changes make the codebase simpler and reduce unnecessary event bubbling between components.

closes: https://github.com/laradumps/app/issues/542