### PR TITLE
feat: window transparency / native OS blur ("glass" effect)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,6 +39,7 @@ const isMac: boolean = process.platform === 'darwin';
 
 let mainWindow: BrowserWindow;
 let badgeCount = 0;
+let blurActive = false;
 const windowsMap = new Map();
 let downloadCompleted = false;
 
@@ -71,18 +72,45 @@ function createWindow(): BrowserWindow {
         browserWindowOptions.trafficLightPosition = { x: 12, y: 11 };
     }
 
+    // Native OS background blur (vibrancy on macOS, acrylic on Windows 11). This MUST be applied at
+    // window creation: Electron's runtime BrowserWindow.setVibrancy() does not engage on macOS
+    // (verified on Electron 41 — it is a no-op in both directions), so toggling the setting in the
+    // UI recreates the window via app.relaunch() instead of mutating vibrancy live.
+    blurActive = !!settings.getSettings().window_blur && (isMac || process.platform === 'win32');
+    if (blurActive) {
+        browserWindowOptions.backgroundColor = '#00000000';
+        if (isMac) {
+            // The glass "mode" picks the look: "mirror" is a true see-through window, every other
+            // value is a native NSVisualEffect (frosted blur) material. `fullscreen-ui` is the most
+            // translucent material — the darker ones (`under-window`, `content`) blend toward black
+            // in dark mode. Mode is a window-creation property, so changing it relaunches the app.
+            const mode = settings.getSettings().window_blur_mode || 'fullscreen-ui';
+            if (mode === 'mirror') {
+                // Alpha is only honored with `transparent: true`; the content behind then shows
+                // through sharply (a mirror/see-through look) instead of the frosted blur.
+                browserWindowOptions.transparent = true;
+            } else {
+                browserWindowOptions.vibrancy = mode;
+                browserWindowOptions.visualEffectState = 'active';
+            }
+        } else {
+            browserWindowOptions.backgroundMaterial = 'acrylic';
+        }
+    }
+
     const window: BrowserWindow = new BrowserWindow(browserWindowOptions);
 
     window.setMenuBarVisibility(false);
 
+    const qs = `screen=default${blurActive ? '&blur=1' : ''}`;
     window.loadURL(
         isDev
-            ? `http://localhost:4999?screen=default`
+            ? `http://localhost:4999?${qs}`
             : format({
                   pathname: join(__dirname, 'app', 'index.html'),
                   protocol: 'file:',
                   slashes: true
-              }) + `?screen=default`
+              }) + `?${qs}`
     );
 
     window.on('resize', (): void => {
@@ -97,7 +125,8 @@ function createWindow(): BrowserWindow {
     window.webContents.on('did-finish-load', async () => {
         try {
             window.webContents.send('init.reply', {
-                settings: settings.getSettings()
+                settings: settings.getSettings(),
+                blurActive
             });
 
             window.show();
@@ -117,7 +146,11 @@ function createWindow(): BrowserWindow {
 
         if (isDev) {
             setTimeout(() => {
-                window.webContents.openDevTools();
+                // Docked DevTools repaints the web contents opaque, which kills the macOS
+                // vibrancy/blur (the window looks transparent for ~1s, then turns opaque the moment
+                // DevTools docks). When the glass effect is active, open DevTools detached — a
+                // separate window — so the transparency survives while developing.
+                window.webContents.openDevTools(blurActive ? { mode: 'detach' } : undefined);
             }, 400);
         }
     });
@@ -392,6 +425,23 @@ ipcMain.on('main:toggle-always-on-top', (event, arg) => {
 
 ipcMain.on('main:is-always-on-top', (event): void => {
     event.reply('main:is-always-on-top', { is_always_on_top: mainWindow.isAlwaysOnTop() });
+});
+
+ipcMain.on('main:relaunch-for-blur', (): void => {
+    const choice = dialog.showMessageBoxSync(mainWindow, {
+        type: 'question',
+        buttons: ['Restart now', 'Later'],
+        defaultId: 0,
+        cancelId: 1,
+        title: 'LaraDumps',
+        message: 'Window transparency change',
+        detail: 'LaraDumps needs to restart to apply the window transparency. Current dumps will be cleared.'
+    });
+
+    if (choice === 0) {
+        app.relaunch();
+        app.exit(0);
+    }
 });
 
 ipcMain.on('main:app-version', (event): void => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import TheNavBar from '@/components/navbar/TheNavBar.vue';
 import { usePayloadStore } from '@/store/payload';
-import { onMounted, ref, watch } from 'vue';
+import { nextTick, onMounted, ref, watch } from 'vue';
 import { useSettingsStore } from '@/store/settings';
 import { useScreenStore } from '@/store/screen';
 import { useLogStore } from '@/store/logs';
@@ -118,7 +118,11 @@ onMounted(() => {
         settingsStore.settings = args.settings;
         readyToLoad.value = true;
         exposeMcp();
+        settingsStore.applyWindowBlur(args.blurActive);
         window.ipcRenderer.send('settings.init-shortcuts');
+
+        await nextTick();
+        settingsStore.applyWindowBlur();
     });
 
     window.ipcRenderer.send('zoom-level');

--- a/src/renderer/default-settings.ts
+++ b/src/renderer/default-settings.ts
@@ -44,5 +44,9 @@ export const DEFAULT_SETTINGS: Settings = {
     split_pane_screen: null,
     grouped_by_time: true,
     display_last_log: false,
-    mcp_limit_payload_objects: 10
+    mcp_limit_payload_objects: 10,
+    window_blur: false,
+    window_blur_mode: 'fullscreen-ui',
+    window_blur_opacity: 50,
+    window_blur_shadow: false
 };

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,6 +3,13 @@
     <head>
         <meta charset="utf-8" />
         <title>LaraDumps</title>
+        <script>
+            // Apply glass-enabled immediately (before CSS loads) to prevent opaque flash.
+            // The main process passes ?blur=1 when native vibrancy/acrylic is active.
+            if (new URLSearchParams(window.location.search).has('blur')) {
+                document.documentElement.classList.add('glass-enabled');
+            }
+        </script>
         <style>
             html {
                 height: 100vh;

--- a/src/renderer/lang/en.js
+++ b/src/renderer/lang/en.js
@@ -83,7 +83,17 @@ export default {
         laravel_jobs: 'Laravel Jobs',
         shortcut_placeholder: 'type here ...',
         appearance: 'Appearance',
-        grouped_by_time: 'Grouped by Time'
+        grouped_by_time: 'Grouped by Time',
+        window_blur: 'Window transparency (blur)',
+        window_blur_mode: 'Glass mode',
+        window_blur_mode_glass: 'Glass (vibrant)',
+        window_blur_mode_mirror: 'Mirror (see-through)',
+        window_blur_mode_hud: 'Glass (dark / HUD)',
+        window_blur_mode_sidebar: 'Glass (sidebar)',
+        window_blur_mode_subtle: 'Glass (subtle)',
+        window_blur_opacity: 'Background opacity',
+        window_blur_shadow: 'Surface shadows',
+        window_blur_hint_win: 'Requires Windows 11'
     },
     copy: 'Copy',
     delete: 'Delete',

--- a/src/renderer/lang/pt-BR.js
+++ b/src/renderer/lang/pt-BR.js
@@ -83,7 +83,17 @@ export default {
         laravel_jobs: 'Laravel Jobs',
         shortcut_placeholder: 'digite aqui ...',
         appearance: 'Aparência',
-        grouped_by_time: 'Agrupar por horário'
+        grouped_by_time: 'Agrupar por horário',
+        window_blur: 'Transparência da janela (blur)',
+        window_blur_mode: 'Modo do vidro',
+        window_blur_mode_glass: 'Vidro (vibrante)',
+        window_blur_mode_mirror: 'Espelho (transparente)',
+        window_blur_mode_hud: 'Vidro (escuro / HUD)',
+        window_blur_mode_sidebar: 'Vidro (sidebar)',
+        window_blur_mode_subtle: 'Vidro (suave)',
+        window_blur_opacity: 'Opacidade do fundo',
+        window_blur_shadow: 'Sombras nas superfícies',
+        window_blur_hint_win: 'Requer Windows 11'
     },
     copy: 'Copiar',
     delete: 'Excluir',

--- a/src/renderer/store/settings.ts
+++ b/src/renderer/store/settings.ts
@@ -139,12 +139,97 @@ export const useSettingsStore = defineStore('settings', () => {
         update();
     };
 
+    // `blurActive` reflects whether the window was actually CREATED with native vibrancy/acrylic
+    // this session (sent by the main process on init). The glass CSS is gated on it because the
+    // effect can only be turned on/off by recreating the window — runtime setVibrancy is a no-op
+    // on macOS. Opacity/shadow are pure CSS and apply live while the effect is active.
+    const blurActive = ref(false);
+    let glassObserver: MutationObserver | null = null;
+
+    // Injects (or updates) a <style> tag appended to the END of <head>.
+    // Cascade rule: the last stylesheet wins when specificity/importance is equal.
+    // Injecting via JS after DaisyUI's CSS guarantees we always come last,
+    // bypassing any @layer ordering issues from the Tailwind/DaisyUI compilation.
+    const GLASS_STYLE_ID = 'ld-glass-override';
+    const injectGlassStyle = () => {
+        const s = settings.value;
+        const pct = `${s.window_blur_opacity ?? 65}%`;
+        const shadows = blurActive.value && !!s.window_blur_shadow;
+
+        let tag = document.getElementById(GLASS_STYLE_ID) as HTMLStyleElement | null;
+        if (!tag) {
+            tag = document.createElement('style');
+            tag.id = GLASS_STYLE_ID;
+            document.head.appendChild(tag);
+        } else {
+            // Re-append to ensure it stays LAST in <head> after any HMR CSS injection
+            document.head.appendChild(tag);
+        }
+
+        tag.textContent = `
+            /* LaraDumps glass/vibrancy override — injected last to win all cascade battles */
+            :root, html, body { background: transparent !important; background-color: transparent !important; background-image: none !important; transition: none !important; animation: none !important; }
+            [data-theme] { background: transparent !important; background-color: transparent !important; background-image: none !important; --root-bg: transparent !important; --page-scroll-bg: transparent !important; --page-scroll-bg-on: transparent !important; }
+            .bg-base-100 { background-color: color-mix(in oklab, var(--color-base-100) ${pct}, transparent) !important; }
+            .bg-base-200 { background-color: color-mix(in oklab, var(--color-base-200) ${pct}, transparent) !important; }
+            .bg-base-300 { background-color: color-mix(in oklab, var(--color-base-300) ${pct}, transparent) !important; }
+            :is(.modal-box, .dropdown-content, .table, .card, .alert, .collapse, .tabs-box) { background-color: color-mix(in oklab, var(--color-base-100) ${pct}, transparent) !important; }
+            ${shadows ? ':is(.bg-base-200, .navbar, .menu, .modal-box, .dropdown-content, .card) { box-shadow: 0 2px 14px color-mix(in oklab, black 28%, transparent); }' : ''}
+        `;
+    };
+
+    const removeGlassStyle = () => {
+        document.getElementById(GLASS_STYLE_ID)?.remove();
+    };
+
+    const applyWindowBlur = (active?: boolean) => {
+        if (typeof active === 'boolean') {
+            blurActive.value = active;
+        }
+
+        const html = document.documentElement;
+
+        if (blurActive.value) {
+            html.classList.add('glass-enabled');
+            html.classList.toggle('glass-shadows', !!settings.value.window_blur_shadow);
+            html.style.setProperty('--glass-pct', `${settings.value.window_blur_opacity ?? 65}%`);
+            injectGlassStyle();
+
+            // Guard: re-assert if anything removes the class (HMR, theme switches, etc.)
+            if (!glassObserver) {
+                glassObserver = new MutationObserver(() => {
+                    if (!html.classList.contains('glass-enabled')) {
+                        glassObserver!.disconnect();
+                        html.classList.add('glass-enabled');
+                        html.classList.toggle('glass-shadows', !!settings.value.window_blur_shadow);
+                        injectGlassStyle();
+                        glassObserver!.observe(html, { attributes: true, attributeFilter: ['class'] });
+                    }
+                });
+                glassObserver.observe(html, { attributes: true, attributeFilter: ['class'] });
+            }
+        } else {
+            if (glassObserver) {
+                glassObserver.disconnect();
+                glassObserver = null;
+            }
+            html.classList.remove('glass-enabled');
+            html.classList.remove('glass-shadows');
+            removeGlassStyle();
+        }
+    };
+
     watch(
         () => settings.value.theme,
         (newTheme) => {
             localStorage.setItem('user-settings', JSON.stringify(settings.value));
             document.documentElement.setAttribute('data-theme', newTheme);
         }
+    );
+
+    watch(
+        () => [settings.value.window_blur_opacity, settings.value.window_blur_shadow],
+        () => applyWindowBlur()
     );
 
     return {
@@ -168,6 +253,7 @@ export const useSettingsStore = defineStore('settings', () => {
         setUpdateDownloading,
         setUpdateProgress,
         markUpdated,
-        setSplitPaneScreen
+        setSplitPaneScreen,
+        applyWindowBlur
     };
 });

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -106,6 +106,76 @@ body {
     padding-bottom: 3rem;
 }
 
+/**
+ * Window transparency / native OS blur ("glass" effect).
+ *
+ * When `glass-enabled` is set on <html>, the window background is let through so the
+ * native OS blur (macOS vibrancy / Windows 11 acrylic) shows behind the UI. DaisyUI paints
+ * opaque base surfaces, so we re-tint them with `color-mix(... transparent)` at the user's
+ * chosen opacity (`--glass-pct`). We override `background-color` at the point of use instead
+ * of redefining `--color-base-*`, which keeps it theme-agnostic and avoids circular vars.
+ *
+ * DaisyUI v5 mechanisms neutralized here:
+ *   - `background: var(--page-scroll-bg, var(--root-bg))` on `:root` + `[data-theme]`
+ *   - `--root-bg: var(--color-base-100)` (opaque solid color)
+ *   - `--page-scroll-bg-on` gradient activated by drawer components
+ *   - `transition: var(--page-scroll-transition)` on :root (can cause opaque fade-in)
+ *   - `animation` on :root for scroll-driven gutter behaviour
+ */
+html.glass-enabled,
+html.glass-enabled body {
+    background: transparent !important;
+    background-color: transparent !important;
+    background-image: none !important;
+}
+
+/* Neutralize all DaisyUI v5 root-background mechanisms on :root itself */
+html.glass-enabled {
+    --root-bg: transparent !important;
+    --page-scroll-bg: transparent !important;
+    --page-scroll-bg-on: transparent !important;
+    --page-has-backdrop: 0 !important;
+    /* cancel the background-color transition DaisyUI sets when drawers open */
+    --page-scroll-transition: none !important;
+    --page-scroll-transition-on: none !important;
+    transition: none !important;
+    /* cancel scroll-driven animation (set-page-has-scroll) on :root */
+    animation: none !important;
+    background: transparent !important;
+    background-color: transparent !important;
+    background-image: none !important;
+}
+
+/* Neutralize DaisyUI's [data-theme] background rule (same mechanism, different selector) */
+html.glass-enabled [data-theme] {
+    --root-bg: transparent !important;
+    --page-scroll-bg: transparent !important;
+    --page-scroll-bg-on: transparent !important;
+    background: transparent !important;
+    background-color: transparent !important;
+    background-image: none !important;
+}
+
+html.glass-enabled .bg-base-100 {
+    background-color: color-mix(in oklab, var(--color-base-100) var(--glass-pct, 65%), transparent) !important;
+}
+html.glass-enabled .bg-base-200 {
+    background-color: color-mix(in oklab, var(--color-base-200) var(--glass-pct, 65%), transparent) !important;
+}
+html.glass-enabled .bg-base-300 {
+    background-color: color-mix(in oklab, var(--color-base-300) var(--glass-pct, 65%), transparent) !important;
+}
+
+/* DaisyUI components that paint base colors via component CSS (not the bg-base-* utility) */
+html.glass-enabled :is(.modal-box, .dropdown-content, .table, .card, .alert, .collapse, .tabs-box) {
+    background-color: color-mix(in oklab, var(--color-base-100) var(--glass-pct, 65%), transparent) !important;
+}
+
+/* Optional surface shadows for legibility over the blurred background */
+html.glass-shadows :is(.bg-base-200, .navbar, .menu, .modal-box, .dropdown-content, .card) {
+    box-shadow: 0 2px 14px color-mix(in oklab, black 28%, transparent);
+}
+
 .nav-bar {
     -webkit-app-region: drag;
     height: 39px;

--- a/src/renderer/types/settings.type.ts
+++ b/src/renderer/types/settings.type.ts
@@ -39,4 +39,8 @@ export interface Settings {
     grouped_by_time: boolean;
     display_last_log: boolean;
     mcp_limit_payload_objects?: number;
+    window_blur: boolean;
+    window_blur_mode: 'mirror' | 'fullscreen-ui' | 'hud' | 'sidebar' | 'under-window';
+    window_blur_opacity: number;
+    window_blur_shadow: boolean;
 }

--- a/src/renderer/views/SettingsView.vue
+++ b/src/renderer/views/SettingsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import Divider from '@/components/common/Divider.vue';
-import { nextTick, onMounted, onUpdated, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, onUpdated, ref, watch } from 'vue';
 import { useSettingsStore } from '@/store/settings';
 import SelectInput from '@/components/common/SelectInput.vue';
 import { useI18n } from 'vue-i18n';
@@ -61,12 +61,21 @@ const { locale } = useI18n({ useScope: 'global' });
 const localeStore = useI18nStore();
 const route = useRoute();
 
+const platform = ref<string>('');
+const blurSupported = computed(() => platform.value === 'darwin' || platform.value === 'win32');
+const isWindows = computed(() => platform.value === 'win32');
+
 onMounted(async () => {
     if (route.query.tab) {
         selected.value = route.query.tab as string;
     }
     customTheme.value = settingsStore.settings.custom_css;
     mcpServerPath.value = await window.ipcRenderer.invoke('get-mcp-server-path');
+
+    window.ipcRenderer.send('platform');
+    window.ipcRenderer.on('platform.reply', (_e: any, p: string) => {
+        platform.value = p;
+    });
 });
 
 const copyMcpCommand = (command: string) => {
@@ -130,6 +139,13 @@ const saveSettings = async () => {
     await settingsStore.update();
 
     toast.show(i18n.t('settings.changes_saved'), 'success');
+};
+
+// Native vibrancy/acrylic can only be applied at window creation, so toggling it asks the main
+// process to confirm and relaunch. Opacity/shadow stay live (handled by the store watcher).
+const saveWindowBlur = async () => {
+    await settingsStore.update();
+    window.ipcRenderer.send('main:relaunch-for-blur');
 };
 
 const saveTheme = async () => {
@@ -666,6 +682,87 @@ const saveCustomTheme = async () => {
                                 </div>
                             </div>
                         </div>
+
+                        <template v-if="blurSupported">
+                            <Divider class="mt-2" />
+                            <div class="mt-2 grid grid-cols-2 items-center">
+                                <div>
+                                    {{ $t('settings.window_blur') }}
+                                    <span
+                                        v-if="isWindows"
+                                        class="block text-xs opacity-60"
+                                        >{{ $t('settings.window_blur_hint_win') }}</span
+                                    >
+                                </div>
+                                <div class="flex items-center justify-end">
+                                    <div class="p-1.5">
+                                        <input
+                                            type="checkbox"
+                                            class="toggle toggle-sm toggle-accent"
+                                            v-model="settingsStore.settings.window_blur"
+                                            @change="saveWindowBlur()"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <template v-if="settingsStore.settings.window_blur">
+                                <template v-if="!isWindows">
+                                    <Divider class="mt-2" />
+                                    <div class="mt-2 grid grid-cols-2 items-center">
+                                        <div>{{ $t('settings.window_blur_mode') }}</div>
+                                        <div class="flex items-center justify-end">
+                                            <SelectInput
+                                                v-model="settingsStore.settings.window_blur_mode"
+                                                @change="saveWindowBlur()"
+                                                :placeholder="$t('settings.window_blur_mode')"
+                                                class="w-full select-sm"
+                                            >
+                                                <option value="fullscreen-ui">{{ $t('settings.window_blur_mode_glass') }}</option>
+                                                <option value="mirror">{{ $t('settings.window_blur_mode_mirror') }}</option>
+                                                <option value="hud">{{ $t('settings.window_blur_mode_hud') }}</option>
+                                                <option value="sidebar">{{ $t('settings.window_blur_mode_sidebar') }}</option>
+                                                <option value="under-window">{{ $t('settings.window_blur_mode_subtle') }}</option>
+                                            </SelectInput>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                <Divider class="mt-2" />
+                                <div class="mt-2 grid grid-cols-2 items-center">
+                                    <div>{{ $t('settings.window_blur_opacity') }}</div>
+                                    <div class="flex items-center justify-end gap-2">
+                                        <input
+                                            type="range"
+                                            min="0"
+                                            max="100"
+                                            step="5"
+                                            class="range range-sm range-accent w-full"
+                                            v-model.number="settingsStore.settings.window_blur_opacity"
+                                            @change="saveSettings()"
+                                        />
+                                        <span class="text-xs w-10 text-right"
+                                            >{{ settingsStore.settings.window_blur_opacity }}%</span
+                                        >
+                                    </div>
+                                </div>
+
+                                <Divider class="mt-2" />
+                                <div class="mt-2 grid grid-cols-2 items-center">
+                                    <div>{{ $t('settings.window_blur_shadow') }}</div>
+                                    <div class="flex items-center justify-end">
+                                        <div class="p-1.5">
+                                            <input
+                                                type="checkbox"
+                                                class="toggle toggle-sm toggle-accent"
+                                                v-model="settingsStore.settings.window_blur_shadow"
+                                                @change="saveSettings()"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            </template>
+                        </template>
                     </div>
 
                     <div


### PR DESCRIPTION
Adds native background blur to the app window on macOS (vibrancy) and Windows 11 (acrylic),
with a live opacity slider, optional surface shadows, and multiple glass modes on macOS.

---

### What changed

**Main process (`src/main/main.ts`)**
- Reads the new `window_blur` / `window_blur_mode` settings at window creation and applies
  `vibrancy` (macOS) or `backgroundMaterial: 'acrylic'` (Windows 11) — the only moment
  Electron supports these properties reliably.
- Passes `?blur=1` on the renderer URL and sends `blurActive` in the `init.reply` IPC event
  so the renderer knows whether the native effect is actually running.
- Adds a `main:relaunch-for-blur` IPC handler that shows a native confirm dialog and calls
  `app.relaunch()` / `app.exit(0)` when the user toggles transparency (required because
  `BrowserWindow.setVibrancy()` is a no-op at runtime on macOS).
- Opens DevTools in `detach` mode while blur is active (docked DevTools repaints content
  opaque, killing vibrancy during development).

**Renderer store (`src/renderer/store/settings.ts`)**
- `applyWindowBlur(active?)` — injects a `<style>` tag last in `<head>` that makes
  `html/body/[data-theme]` transparent and re-tints DaisyUI surface classes
  (`bg-base-100/200/300` + common components) via `color-mix(in oklab, … transparent)`
  at the user's chosen opacity.
- A `MutationObserver` re-asserts `glass-enabled` if anything (HMR, theme switches)
  removes it.
- Watches `window_blur_opacity` and `window_blur_shadow` to update CSS live without
  relaunching.

**Renderer entry (`src/renderer/index.html`)**
- Inline `<script>` in `<head>` adds `glass-enabled` before any CSS loads when
  `?blur=1` is present — prevents the opaque white/dark flash on startup.

**App root (`src/renderer/App.vue`)**
- Calls `applyWindowBlur(args.blurActive)` on `init.reply`, then again after `nextTick`
  to cover async DaisyUI/theme initialisation that can repaint surfaces.

**Settings UI (`src/renderer/views/SettingsView.vue`)**
- New "Window transparency (blur)" section under Appearance, shown only on
  macOS and Windows (`blurSupported` computed).
- Toggle → triggers relaunch dialog (required for native blur to take effect).
- Glass mode selector (macOS only): Glass (vibrant), Mirror (see-through), HUD, Sidebar, Subtle.
- Opacity range slider (0–100%, live preview).
- Surface shadows toggle (live preview).

**Types & defaults**
- `Settings` interface extended with `window_blur`, `window_blur_mode`,
  `window_blur_opacity`, `window_blur_shadow`.
- Default: off, mode `fullscreen-ui`, opacity 50%, shadows off.

**i18n** — keys added to `en.js` and `pt-BR.js`.

---

### Behaviour notes

| Scenario | Behaviour |
|---|---|
| Toggle ON/OFF | Confirm dialog → relaunch |
| Change glass mode (macOS) | Confirm dialog → relaunch |
| Change opacity | Live (CSS `color-mix` update, no relaunch) |
| Change shadows | Live (CSS `box-shadow` update, no relaunch) |
| Windows < 11 | Section hidden |
| Linux | Section hidden |
