### PR TITLE
Fix: Update progress bar and show release notes in toast

### DIFF
--- a/src/main/auto-update.ts
+++ b/src/main/auto-update.ts
@@ -95,8 +95,12 @@ const downloadUpdateMacOS = async (): Promise<void> => {
 
     try {
         await download(mainWindow, downloadURL, {
-            onProgress: (progress: number) => {
-                mainWindow.webContents.send('autoUpdater:download-progress', { percent: progress * 100 });
+            onProgress: (progress) => {
+                mainWindow.webContents.send('autoUpdater:download-progress', {
+                    percent: progress.percent * 100,
+                    transferredBytes: progress.transferredBytes,
+                    totalBytes: progress.totalBytes
+                });
             },
             onCompleted: () => {
                 console.log('[AutoUpdater] Download completed');

--- a/src/renderer/components/app/TheUpdateNotification.vue
+++ b/src/renderer/components/app/TheUpdateNotification.vue
@@ -1,19 +1,64 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { ArrowDownTrayIcon } from '@heroicons/vue/24/solid';
+import { ChevronDownIcon } from '@heroicons/vue/24/outline';
 import { useSettingsStore } from '@/store/settings';
 import { UpdateInfo } from 'electron-updater';
 import { DownloadInfo } from '@/types/Updater';
+import { escapeHtml, isHtmlContent, sanitizeReleaseNotesHtml } from '@/utils/sanitizeReleaseNotesHtml';
 
 const settingsStore = useSettingsStore();
 const updateInfo = ref<Partial<UpdateInfo>>({});
+const showReleaseNotes = ref(false);
 
 const show = computed(() => settingsStore.updateAvailable);
 const downloading = computed(() => settingsStore.updateDownloading);
 const progress = computed(() => settingsStore.updateProgress);
 const isAutoInstallMode = computed(() => settingsStore.settings.check_for_updates === 'auto_install');
 
+const rawReleaseNotes = computed(() => {
+    const notes = updateInfo.value.releaseNotes;
+
+    if (!notes) {
+        return '';
+    }
+
+    if (typeof notes === 'string') {
+        return notes.trim();
+    }
+
+    if (Array.isArray(notes)) {
+        return notes
+            .map((note) => {
+                const version = note.version ? `<h2>${escapeHtml(note.version)}</h2>` : '';
+                const body = note.note ?? '';
+                const safeBody = isHtmlContent(body) ? body : escapeHtml(body).replace(/\n/g, '<br>');
+
+                return `${version}${safeBody}`.trim();
+            })
+            .filter(Boolean)
+            .join('');
+    }
+
+    return '';
+});
+
+const releaseNotesHtml = computed(() => {
+    if (!rawReleaseNotes.value) {
+        return '';
+    }
+
+    if (isHtmlContent(rawReleaseNotes.value)) {
+        return sanitizeReleaseNotesHtml(rawReleaseNotes.value);
+    }
+
+    return `<p>${escapeHtml(rawReleaseNotes.value).replace(/\n/g, '<br>')}</p>`;
+});
+
+const hasReleaseNotes = computed(() => releaseNotesHtml.value.length > 0);
+
 const close = () => {
+    showReleaseNotes.value = false;
     settingsStore.markUpdated();
 };
 
@@ -30,9 +75,26 @@ const notYet = () => {
     close();
 };
 
+const toggleReleaseNotes = () => {
+    showReleaseNotes.value = !showReleaseNotes.value;
+};
+
+const onReleaseNotesClick = (event: MouseEvent) => {
+    const target = event.target as HTMLElement | null;
+    const anchor = target?.closest('a');
+
+    if (!anchor?.href) {
+        return;
+    }
+
+    event.preventDefault();
+    window.ipcRenderer.send('main:openLink', anchor.href);
+};
+
 const onUpdateAvailable = (_: any, info: UpdateInfo) => {
     console.log('[Renderer] Update available:', info);
     updateInfo.value = info;
+    showReleaseNotes.value = false;
 
     if (isAutoInstallMode.value) {
         console.log('[Renderer] Auto-downloading update in background (auto_install mode)...');
@@ -64,6 +126,7 @@ const onDownloadProgress = (_: any, args: DownloadInfo): void => {
 
 const onUpdateDownloaded = (_: any, info: UpdateInfo): void => {
     console.log('[Renderer] Update downloaded:', info);
+    updateInfo.value = info;
 
     if (isAutoInstallMode.value) {
         settingsStore.setUpdateAvailable(info?.version);
@@ -118,6 +181,32 @@ onUnmounted(() => {
                                   })
                         }}
                     </div>
+
+                    <button
+                        v-if="hasReleaseNotes"
+                        type="button"
+                        class="mt-2 inline-flex items-center gap-1 text-xs text-accent hover:text-accent/80 transition-colors"
+                        @click="toggleReleaseNotes"
+                    >
+                        {{ $t('app_update_info.whats_new') }}
+                        <ChevronDownIcon
+                            class="w-3.5 h-3.5 transition-transform duration-200"
+                            :class="{ 'rotate-180': showReleaseNotes }"
+                        />
+                    </button>
+
+                    <Transition name="notes">
+                        <div
+                            v-if="hasReleaseNotes && showReleaseNotes"
+                            class="mt-2 border-t border-neutral-content/10 pt-2"
+                        >
+                            <div
+                                class="release-notes max-h-40 overflow-y-auto rounded-md bg-neutral-content/5 p-2 text-xs text-neutral-content/70 leading-relaxed"
+                                v-html="releaseNotesHtml"
+                                @click="onReleaseNotesClick"
+                            />
+                        </div>
+                    </Transition>
 
                     <div
                         v-if="downloading && !isAutoInstallMode"
@@ -175,5 +264,80 @@ onUnmounted(() => {
 .slide-up-leave-to {
     opacity: 0;
     transform: translateY(20px);
+}
+
+.notes-enter-active,
+.notes-leave-active {
+    transition: all 0.2s ease;
+    overflow: hidden;
+}
+
+.notes-enter-from,
+.notes-leave-to {
+    opacity: 0;
+    max-height: 0;
+    margin-top: 0;
+    padding-top: 0;
+}
+
+.notes-enter-to,
+.notes-leave-from {
+    opacity: 1;
+    max-height: 11rem;
+}
+
+.release-notes :deep(h1),
+.release-notes :deep(h2),
+.release-notes :deep(h3),
+.release-notes :deep(h4) {
+    color: var(--color-neutral-content);
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.release-notes :deep(ul),
+.release-notes :deep(ol) {
+    list-style: disc;
+    padding-left: 1.1rem;
+    margin: 0;
+}
+
+.release-notes :deep(li) {
+    margin-bottom: 0.4rem;
+}
+
+.release-notes :deep(li:last-child) {
+    margin-bottom: 0;
+}
+
+.release-notes :deep(a) {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.release-notes :deep(a:hover) {
+    opacity: 0.8;
+}
+
+.release-notes :deep(p) {
+    margin-top: 0.5rem;
+}
+
+.release-notes :deep(p:first-child) {
+    margin-top: 0;
+}
+
+.release-notes :deep(strong),
+.release-notes :deep(b) {
+    color: var(--color-neutral-content);
+    font-weight: 600;
+}
+
+.release-notes :deep(code),
+.release-notes :deep(tt) {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.7rem;
 }
 </style>

--- a/src/renderer/lang/al-AL.js
+++ b/src/renderer/lang/al-AL.js
@@ -120,7 +120,8 @@ export default {
         not_now: 'Not now',
         install: 'Install',
         version: 'Version',
-        release_date: 'Release Date'
+        release_date: 'Release Date',
+        whats_new: "What's new"
     },
     pause: 'Pause',
     remove: 'Remove',

--- a/src/renderer/lang/ar-AR.js
+++ b/src/renderer/lang/ar-AR.js
@@ -119,7 +119,8 @@ export default {
         not_now: 'ليس الآن',
         install: 'ثبت',
         version: 'النسخة',
-        release_date: 'تاريخ الإصدار'
+        release_date: 'تاريخ الإصدار',
+        whats_new: 'ما الجديد'
     },
     pause: 'Pause',
     remove: 'Remove',

--- a/src/renderer/lang/en.js
+++ b/src/renderer/lang/en.js
@@ -141,7 +141,8 @@ export default {
         restart: 'Restart',
         version: 'Version',
         release_date: 'Release Date',
-        ready_to_install: 'Ready to Install'
+        ready_to_install: 'Ready to Install',
+        whats_new: "What's new"
     },
     pause: 'Pause',
     remove: 'Remove',

--- a/src/renderer/lang/es-ES.js
+++ b/src/renderer/lang/es-ES.js
@@ -120,7 +120,8 @@ export default {
         not_now: 'Not now',
         install: 'Install',
         version: 'Version',
-        release_date: 'Release Date'
+        release_date: 'Release Date',
+        whats_new: 'Novedades'
     },
     pause: 'Pause',
     remove: 'Remove',

--- a/src/renderer/lang/fa-IR.js
+++ b/src/renderer/lang/fa-IR.js
@@ -120,7 +120,8 @@ export default {
         not_now: 'Not now',
         install: 'Install',
         version: 'Version',
-        release_date: 'Release Date'
+        release_date: 'Release Date',
+        whats_new: "What's new"
     },
     pause: 'Pause',
     remove: 'Remove',

--- a/src/renderer/lang/id-ID.js
+++ b/src/renderer/lang/id-ID.js
@@ -120,7 +120,8 @@ export default {
         not_now: 'Not now',
         install: 'Install',
         version: 'Version',
-        release_date: 'Release Date'
+        release_date: 'Release Date',
+        whats_new: "What's new"
     },
     pause: 'Pause',
     remove: 'Remove',

--- a/src/renderer/lang/it-IT.js
+++ b/src/renderer/lang/it-IT.js
@@ -120,7 +120,8 @@ export default {
         not_now: 'Not now',
         install: 'Install',
         version: 'Version',
-        release_date: 'Release Date'
+        release_date: 'Release Date',
+        whats_new: "Cosa c'è di nuovo"
     },
     pause: 'Pause',
     remove: 'Remove',

--- a/src/renderer/lang/ko-KR.js
+++ b/src/renderer/lang/ko-KR.js
@@ -119,7 +119,8 @@ export default {
         not_now: '나중에',
         install: '설치',
         version: '버전',
-        release_date: '출시일'
+        release_date: '출시일',
+        whats_new: '새로운 기능'
     },
     pause: '일시정지',
     remove: '제거',

--- a/src/renderer/lang/pt-BR.js
+++ b/src/renderer/lang/pt-BR.js
@@ -139,7 +139,8 @@ export default {
         restart: 'Reiniciar',
         version: 'Versão',
         release_date: 'Data de lançamento',
-        ready_to_install: 'Pronto para Instalar'
+        ready_to_install: 'Pronto para Instalar',
+        whats_new: 'Ver novidades'
     },
     pause: 'Pausar',
     remove: 'Remover',

--- a/src/renderer/lang/tr-TR.js
+++ b/src/renderer/lang/tr-TR.js
@@ -121,7 +121,8 @@ export default {
         not_now: 'Şimdi değil',
         install: 'Yükle',
         version: 'Sürüm',
-        release_date: 'Yayınlanma Tarihi'
+        release_date: 'Yayınlanma Tarihi',
+        whats_new: 'Yenilikler'
     },
     pause: 'Duraklat',
     remove: 'Kaldır',

--- a/src/renderer/lang/zh-CN.js
+++ b/src/renderer/lang/zh-CN.js
@@ -119,7 +119,8 @@ export default {
         not_now: '以后再说',
         install: '安装',
         version: '版本',
-        release_date: '发布日期'
+        release_date: '发布日期',
+        whats_new: '更新内容'
     },
     pause: '暂停',
     remove: '移除',

--- a/src/renderer/utils/sanitizeReleaseNotesHtml.ts
+++ b/src/renderer/utils/sanitizeReleaseNotesHtml.ts
@@ -1,0 +1,91 @@
+const ALLOWED_TAGS = new Set([
+    'H1',
+    'H2',
+    'H3',
+    'H4',
+    'H5',
+    'H6',
+    'P',
+    'UL',
+    'OL',
+    'LI',
+    'A',
+    'STRONG',
+    'EM',
+    'B',
+    'I',
+    'CODE',
+    'PRE',
+    'BR',
+    'TT'
+]);
+
+function escapeAttr(value: string): string {
+    return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+export function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function sanitizeElement(el: Element): string {
+    let result = '';
+
+    for (const node of Array.from(el.childNodes)) {
+        if (node.nodeType === Node.TEXT_NODE) {
+            result += node.textContent ?? '';
+            continue;
+        }
+
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            continue;
+        }
+
+        const child = node as Element;
+        const tag = child.tagName.toUpperCase();
+
+        if (tag === 'BR') {
+            result += '<br>';
+            continue;
+        }
+
+        if (!ALLOWED_TAGS.has(tag)) {
+            result += sanitizeElement(child);
+            continue;
+        }
+
+        const inner = sanitizeElement(child);
+
+        if (tag === 'A') {
+            const href = child.getAttribute('href') ?? '';
+            const safeHref = /^https?:\/\//i.test(href) ? href : '';
+
+            result += safeHref ? `<a href="${escapeAttr(safeHref)}">${inner}</a>` : inner;
+            continue;
+        }
+
+        const lower = tag.toLowerCase();
+        result += `<${lower}>${inner}</${lower}>`;
+    }
+
+    return result;
+}
+
+export function isHtmlContent(value: string): boolean {
+    return /<[a-z][\s\S]*>/i.test(value);
+}
+
+export function sanitizeReleaseNotesHtml(html: string): string {
+    const doc = new DOMParser().parseFromString(`<div>${html}</div>`, 'text/html');
+    const root = doc.body.firstElementChild;
+
+    if (!root) {
+        return '';
+    }
+
+    return sanitizeElement(root).trim();
+}


### PR DESCRIPTION
## Summary
- Fix macOS update download progress: `electron-dl` now sends `progress.percent` (and byte totals) instead of treating the progress callback as a bare number, so the toast progress bar updates correctly.
- Add expandable “What’s new” release notes to the update toast (available and downloaded states), rendering sanitized GitHub HTML with scroll and external links.

## Test plan
- [ ] On macOS, trigger an update download and confirm the progress bar advances from 0→100%
- [ ] Open “What’s new” on Update Available and confirm release notes render as a list (not raw HTML)
- [ ] Confirm long notes scroll inside the toast and action buttons stay visible
- [ ] Click a PR/user link in the notes and confirm it opens in the browser
- [ ] After download completes, confirm notes still work on Update Downloaded
- [ ] Confirm the toggle is hidden when `releaseNotes` is empty