### PR TITLE
Fix: Restore global search results and sync tab counts

### DIFF
--- a/src/renderer/components/navbar/NavBarGlobalSearch.vue
+++ b/src/renderer/components/navbar/NavBarGlobalSearch.vue
@@ -42,6 +42,11 @@ const activateBadge = (badge) => {
     const map = { dumps: 'home', logs: 'logs', jobs: 'jobs', mail: 'mail', queries: 'queries' };
     const target = map[badge.key] || badge.key;
     screenStore.activeScreen?.(target);
+
+    payloadStore.filteredPayload = payloadStore.payload.filter(
+        (payload) => payload.type !== 'screen' && payload.to_screen?.screen_name === target
+    );
+
     showInput.value = false;
 };
 

--- a/src/renderer/components/screen/Screens.vue
+++ b/src/renderer/components/screen/Screens.vue
@@ -9,6 +9,7 @@ import { useTailLogStore } from '@/store/tail-log';
 import { useQueriesPayloadStore } from '@/store/queries.js';
 import { useSplitPanesStore } from '@/store/split-panes';
 import { useBrainStore } from '@/store/brains.ts';
+import { useGlobalSearchStore } from '@/store/global-search';
 import EnvironmentDropdown from './EnvironmentDropdown.vue';
 import type { Environment } from '../../../main/storage';
 import { XMarkIcon } from '@heroicons/vue/20/solid';
@@ -35,6 +36,7 @@ const tailLogStore = useTailLogStore();
 const brainStore = useBrainStore();
 const queriesStore = useQueriesPayloadStore();
 const splitPanesStore = useSplitPanesStore();
+const globalSearchStore = useGlobalSearchStore();
 
 const showTooltip = ref(false);
 const isDraggingIndex = ref(null);
@@ -150,6 +152,67 @@ window.ipcRenderer.on('screen-window:closed', (event, args) => {
     }, 200);
 });
 
+const matchesSearch = (screenName: string, item: any, term: string): boolean => {
+    if (!term) return true;
+
+    switch (screenName) {
+        case 'logs':
+        case 'tail_logs':
+            return (
+                String(item.message ?? '')
+                    .toLowerCase()
+                    .includes(term) ||
+                String(item.level ?? '')
+                    .toLowerCase()
+                    .includes(term) ||
+                String(Array.isArray(item.context) ? (item.context[0] ?? '') : (item.context ?? ''))
+                    .toLowerCase()
+                    .includes(term)
+            );
+        case 'jobs':
+            return (
+                String(item.display_name ?? '')
+                    .toLowerCase()
+                    .includes(term) ||
+                String(item.job_id ?? '')
+                    .toLowerCase()
+                    .includes(term) ||
+                String(Array.isArray(item.job) ? (item.job[0] ?? '') : (item.job ?? ''))
+                    .toLowerCase()
+                    .includes(term)
+            );
+        case 'mail':
+            return JSON.stringify(item).toLowerCase().includes(term);
+        case 'queries':
+            return (
+                String(item?.with_label?.label ?? '')
+                    .toLowerCase()
+                    .includes(term) ||
+                String(item?.queries?.query?.sql ?? '')
+                    .toLowerCase()
+                    .includes(term)
+            );
+        case 'brain':
+            return (
+                String(item.className ?? '')
+                    .toLowerCase()
+                    .includes(term) ||
+                String(item.run_workflow_id ?? '')
+                    .toLowerCase()
+                    .includes(term)
+            );
+        default: {
+            const content = item?.[item.type] ?? '';
+            return (
+                JSON.stringify(content).toLowerCase().includes(term) ||
+                JSON.stringify(item?.with_label ?? '')
+                    .toLowerCase()
+                    .includes(term)
+            );
+        }
+    }
+};
+
 const getPayloadScreenCount = (screenName) => {
     const stores = {
         jobs: jobStore.jobs,
@@ -161,14 +224,17 @@ const getPayloadScreenCount = (screenName) => {
     };
 
     const items = stores[screenName] || payloadStore.get(screenName);
+    const term = globalSearchStore.search.toLowerCase();
 
-    let count = 0;
+    let list: any[] = [];
 
     if (Array.isArray(items)) {
-        count = items.length;
+        list = items;
     } else if (items && typeof items === 'object') {
-        count = Object.keys(items).length;
+        list = Object.values(items);
     }
+
+    const count = list.filter((item) => matchesSearch(screenName, item, term)).length;
 
     return count > 0 ? `(${count})` : '';
 };

--- a/src/renderer/views/HomeView.vue
+++ b/src/renderer/views/HomeView.vue
@@ -804,12 +804,20 @@ const clearDumpListeners = () => {
 };
 
 const dumpsBagFiltered = computed((): Payload[] => {
+    const search = globalSearchStore.search.toLowerCase();
+
     return payloadStore.filteredPayload
-        .filter(
-            (dump: Payload) =>
-                dump.content?.toLowerCase().includes(globalSearchStore.search.toLowerCase()) ||
-                JSON.stringify(dump.with_label)?.toLowerCase().includes(globalSearchStore.search.toLowerCase())
-        )
+        .filter((dump: Payload) => {
+            if (!search) {
+                return true;
+            }
+
+            const content = dump[dump.type] ?? '';
+            const contentMatch = JSON.stringify(content).toLowerCase().includes(search);
+            const labelMatch = JSON.stringify(dump.with_label ?? '').toLowerCase().includes(search);
+
+            return contentMatch || labelMatch;
+        })
         .filter((dump: Payload) => {
             if (colorStore.colors.length > 0 && dump.color) {
                 return colorStore.colors.includes(dump.color);


### PR DESCRIPTION
## Summary
- Fix dump search matching to use `dump[dump.type]` instead of the non-existent `dump.content`, so filtered results render again instead of blank tabs
- Sync `filteredPayload` when activating a search badge, so navigation lands on the correct screen content
- Update tab counts (Home, Mail, Logs, Jobs, Queries, Brain, etc.) to reflect the active search filter

## Test plan
- [ ] Search for a known dump value and confirm matching dumps appear in the list (not a blank screen)
- [ ] Confirm search badges show correct counts and clicking a badge opens the matching screen with content
- [ ] Confirm tab counts update to filtered totals while searching (e.g. `Home (3)` instead of total dumps)
- [ ] Confirm Mail, Logs, Jobs, and Queries tab counts also reflect the search term
- [ ] Clear the search and confirm counts/lists return to the full unfiltered state